### PR TITLE
Added dependencies = TRUE comment for recommended install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ You can install the latest stable version of **fastml** from CRAN using:
 install.packages("fastml")
 ```
 
+You can install all dependencies (additional models) using:
+```r
+# install all dependencies - recommended
+install.packages("fastml", dependencies = TRUE)
+```
+
 ### From GitHub
 For the development version, install directly from GitHub using the devtools package:
 


### PR DESCRIPTION
Added `dependencies = TRUE` to docs as you have a number of Suggests that should be installed for the default `fastml` function to work.