### PR TITLE
Fix evaluate_models single workflow

### DIFF
--- a/R/evaluate_models.R
+++ b/R/evaluate_models.R
@@ -32,6 +32,8 @@ evaluate_models <- function(models, train_data, test_data, label, task, metric =
     }
   }
 
+  # Determine engine names for each algorithm
+  engine_names <- get_engine_names(models)
   # Initialize performance and predictions lists
   performance <- list()
   predictions_list <- list()
@@ -59,7 +61,11 @@ evaluate_models <- function(models, train_data, test_data, label, task, metric =
       }
     } else {
       # Otherwise, assume a single model (not nested)
-      result <- process_model(models[[algo]], algo)
+      eng <- if (!is.null(engine_names[[algo]])) engine_names[[algo]][1] else NA
+      result <- process_model(models[[algo]], model_id = algo,
+                              task = task, test_data = test_data,
+                              label = label, event_class = event_class,
+                              engine = eng)
       if (!is.null(result)) {
         performance[[algo]] <- result$performance
         predictions_list[[algo]] <- result$predictions

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -179,6 +179,20 @@ test_that("stop if recipe is not correctly specified.", {
   })
 })
 
+test_that("evaluate_models works with a single workflow", {
+  rec <- recipes::recipe(Species ~ ., data = iris)
+  spec <- parsnip::logistic_reg() %>% parsnip::set_engine("glm")
+  wf <- workflows::workflow() %>%
+    workflows::add_model(spec) %>%
+    workflows::add_recipe(rec)
+  fitted_wf <- parsnip::fit(wf, data = iris)
+  models <- list(log_reg = fitted_wf)
+  eval_res <- evaluate_models(models, iris, iris,
+                              label = "Species", task = "classification",
+                              metric = "accuracy", event_class = "second")
+  expect_true("log_reg" %in% names(eval_res$performance))
+})
+
 # test_that("regression model successful.", {
 #   expect_no_error({
 #     fastml(


### PR DESCRIPTION
## Summary
- ensure evaluate_models passes engine when only a single workflow is supplied
- determine engine names inside evaluate_models
- test evaluate_models with a single workflow

## Testing
- `R CMD check .` *(fails: Required fields missing or empty)*

------
https://chatgpt.com/codex/tasks/task_e_684142aff1c4832aa045a86f03a5114a