### PR TITLE
Refactor process_model to accept train data and metric

### DIFF
--- a/R/evaluate_models.R
+++ b/R/evaluate_models.R
@@ -53,7 +53,8 @@ evaluate_models <- function(models, train_data, test_data, label, task, metric =
         model_obj <- models[[algo]][[eng]]
         result <- process_model(model_obj, model_id = paste(algo, eng, sep = "_"),
                                 task = task, test_data = test_data, label = label,
-                                event_class = event_class, engine = eng)
+                                event_class = event_class, engine = eng,
+                                train_data = train_data, metric = metric)
         if (!is.null(result)) {
           performance[[algo]][[eng]] <- result$performance
           predictions_list[[algo]][[eng]] <- result$predictions
@@ -65,7 +66,8 @@ evaluate_models <- function(models, train_data, test_data, label, task, metric =
       result <- process_model(models[[algo]], model_id = algo,
                               task = task, test_data = test_data,
                               label = label, event_class = event_class,
-                              engine = eng)
+                              engine = eng, train_data = train_data,
+                              metric = metric)
       if (!is.null(result)) {
         performance[[algo]] <- result$performance
         predictions_list[[algo]] <- result$predictions

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -808,7 +808,6 @@ get_default_tune_params <- function(algo, train_data, label, engine) {
          NULL)
 }
 
-utils::globalVariables(c("metric", "train_data", "true_labels"))
 #' Process Model and Compute Performance Metrics
 #'
 #' Finalizes a tuning result or utilizes an already fitted workflow to generate predictions on test data and compute performance metrics.
@@ -820,6 +819,8 @@ utils::globalVariables(c("metric", "train_data", "true_labels"))
 #' @param label A character string specifying the name of the outcome variable in \code{test_data}.
 #' @param event_class For classification tasks, a character string specifying which event class to consider as positive (accepted values: \code{"first"} or \code{"second"}).
 #' @param engine A character string specifying the modeling engine used. This parameter affects prediction types and metric computations.
+#' @param train_data A data frame containing the training data used to fit tuned models.
+#' @param metric A character string specifying the metric name used to select the best tuning parameters.
 #'
 #' @return A list with two components:
 #'   \describe{
@@ -832,7 +833,7 @@ utils::globalVariables(c("metric", "train_data", "true_labels"))
 #'     \item Select the best tuning parameters using \code{tune::select_best} (note that the metric used for selection should be defined in the calling environment).
 #'     \item Extract the model specification and preprocessor from \code{model_obj} using \code{workflows::pull_workflow_spec} and \code{workflows::pull_workflow_preprocessor}, respectively.
 #'     \item Finalize the model specification with the selected parameters via \code{tune::finalize_model}.
-#'     \item Rebuild the workflow using \code{workflows::workflow}, \code{workflows::add_recipe}, and \code{workflows::add_model}, and fit the finalized workflow with \code{parsnip::fit} on training data (the variable \code{train_data} is expected to be available in the environment).
+#'     \item Rebuild the workflow using \code{workflows::workflow}, \code{workflows::add_recipe}, and \code{workflows::add_model}, and fit the finalized workflow with \code{parsnip::fit} on the supplied \code{train_data}.
 #'   }
 #'   If \code{model_obj} is already a fitted workflow, it is used directly.
 #'
@@ -852,7 +853,8 @@ utils::globalVariables(c("metric", "train_data", "true_labels"))
 #' @importFrom magrittr %>%
 #'
 #' @export
-process_model <- function(model_obj, model_id, task, test_data, label, event_class, engine) {
+process_model <- function(model_obj, model_id, task, test_data, label, event_class,
+                          engine, train_data, metric) {
   # If the model object is a tuning result, finalize the workflow
   if (inherits(model_obj, "tune_results")) {
     best_params <- tryCatch({

--- a/man/process_model.Rd
+++ b/man/process_model.Rd
@@ -4,7 +4,8 @@
 \alias{process_model}
 \title{Process Model and Compute Performance Metrics}
 \usage{
-process_model(model_obj, model_id, task, test_data, label, event_class, engine)
+process_model(model_obj, model_id, task, test_data, label, event_class, engine,
+  train_data, metric)
 }
 \arguments{
 \item{model_obj}{A model object, which can be either a tuning result (an object inheriting from \code{"tune_results"}) or an already fitted workflow.}
@@ -20,6 +21,10 @@ process_model(model_obj, model_id, task, test_data, label, event_class, engine)
 \item{event_class}{For classification tasks, a character string specifying which event class to consider as positive (accepted values: \code{"first"} or \code{"second"}).}
 
 \item{engine}{A character string specifying the modeling engine used. This parameter affects prediction types and metric computations.}
+
+\item{train_data}{Training data frame used when finalizing tuned models.}
+
+\item{metric}{Metric name used to select the best tuning parameters.}
 }
 \value{
 A list with two components:
@@ -37,7 +42,7 @@ The function first checks if \code{model_obj} is a tuning result. If so, it atte
     \item Select the best tuning parameters using \code{tune::select_best} (note that the metric used for selection should be defined in the calling environment).
     \item Extract the model specification and preprocessor from \code{model_obj} using \code{workflows::pull_workflow_spec} and \code{workflows::pull_workflow_preprocessor}, respectively.
     \item Finalize the model specification with the selected parameters via \code{tune::finalize_model}.
-    \item Rebuild the workflow using \code{workflows::workflow}, \code{workflows::add_recipe}, and \code{workflows::add_model}, and fit the finalized workflow with \code{parsnip::fit} on training data (the variable \code{train_data} is expected to be available in the environment).
+    \item Rebuild the workflow using \code{workflows::workflow}, \code{workflows::add_recipe}, and \code{workflows::add_model}, and fit the finalized workflow with \code{parsnip::fit} on the provided \code{train_data}.
   }
   If \code{model_obj} is already a fitted workflow, it is used directly.
 

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -193,6 +193,22 @@ test_that("evaluate_models works with a single workflow", {
   expect_true("log_reg" %in% names(eval_res$performance))
 })
 
+test_that("process_model works without global variables", {
+  rec <- recipes::recipe(Species ~ ., data = iris)
+  spec <- parsnip::logistic_reg() %>% parsnip::set_engine("glm")
+  wf <- workflows::workflow() %>%
+    workflows::add_model(spec) %>%
+    workflows::add_recipe(rec)
+  fitted_wf <- parsnip::fit(wf, data = iris)
+
+  res <- process_model(fitted_wf, model_id = "log_reg", task = "classification",
+                       test_data = iris, label = "Species",
+                       event_class = "second", engine = "glm",
+                       train_data = iris, metric = "accuracy")
+  expect_s3_class(res$performance, "tbl_df")
+  expect_equal(nrow(res$predictions), nrow(iris))
+})
+
 # test_that("regression model successful.", {
 #   expect_no_error({
 #     fastml(


### PR DESCRIPTION
## Summary
- add `train_data` and `metric` parameters to `process_model`
- pass these new arguments from `evaluate_models`
- remove now unnecessary globalVariables call
- document the updated interface
- test `process_model` directly

## Testing
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841449bcf1c832ab0e3d4846bd983b8