### PR TITLE
Handle no-tuning strategy

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -270,6 +270,10 @@ train_models <- function(train_data,
       }else{
 
       perform_tuning <- !all(vapply(engine_tune_params, is.null, logical(1))) && !is.null(resamples)
+
+      if (tuning_strategy == "none") {
+        perform_tuning <- FALSE
+      }
       }
 
        # For other algorithms, use a switch that uses the current engine

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -99,7 +99,7 @@ Default is \code{"error"}.}
 
 \item{use_default_tuning}{Logical indicating whether to use default tuning grids when \code{tune_params} is \code{NULL}. Default is \code{FALSE}.}
 
-\item{tuning_strategy}{A string specifying the tuning strategy. Options might include \code{"grid"}, \code{"bayes"}, or \code{"none"}. Default is \code{"grid"}.}
+\item{tuning_strategy}{A string specifying the tuning strategy. Options might include \code{"grid"}, \code{"bayes"}, or \code{"none"}. If \code{"none"} is used, the workflow is fitted directly without tuning. Default is \code{"grid"}.}
 
 \item{tuning_iterations}{Number of tuning iterations (applicable for Bayesian or other iterative search methods). Default is \code{10}.}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -52,7 +52,7 @@ train_models(
 
 \item{use_default_tuning}{Logical indicating whether to use default tuning grids when \code{tune_params} is \code{NULL}.}
 
-\item{tuning_strategy}{A string specifying the tuning strategy ("grid", "bayes", or "none"), possibly with adaptive methods.}
+\item{tuning_strategy}{A string specifying the tuning strategy ("grid", "bayes", or "none"), possibly with adaptive methods. If set to \code{"none"}, the workflow is fitted directly without tuning.}
 
 \item{tuning_iterations}{Number of iterations for iterative tuning methods.}
 


### PR DESCRIPTION
## Summary
- skip tuning when `tuning_strategy` is `"none"`
- document direct fitting for `tuning_strategy = "none"`

## Testing
- `R CMD build .`
- `R CMD check fastml_0.6.1.tar.gz` *(fails: Packages required but not available)*

------
https://chatgpt.com/codex/tasks/task_e_685120efa7f8832aafd1a56654857e23