### PR TITLE
Fix tuning conditional logic

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -48,7 +48,7 @@ utils::globalVariables(c("Fraction", "Performance"))
 #' @param encode_categoricals Logical indicating whether to encode categorical variables. Default is \code{TRUE}.
 #' @param scaling_methods Vector of scaling methods to apply. Default is \code{c("center", "scale")}.
 #' @param summaryFunction A custom summary function for model evaluation. Default is \code{NULL}.
-#' @param use_default_tuning Logical indicating whether to use default tuning grids when \code{tune_params} is \code{NULL}. Default is \code{FALSE}.
+#' @param use_default_tuning Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, models are fitted once with default settings. Default is \code{FALSE}.
 #' @param tuning_strategy A string specifying the tuning strategy. Options might include \code{"grid"}, \code{"bayes"}, or \code{"none"}. Default is \code{"grid"}.
 #' @param tuning_iterations Number of tuning iterations (applicable for Bayesian or other iterative search methods). Default is \code{10}.
 #' @param early_stopping Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -17,7 +17,7 @@
 #' @param summaryFunction A custom summary function for model evaluation. Default is \code{NULL}.
 #' @param seed An integer value specifying the random seed for reproducibility.
 #' @param recipe A recipe object for preprocessing.
-#' @param use_default_tuning Logical indicating whether to use default tuning grids when \code{tune_params} is \code{NULL}.
+#' @param use_default_tuning Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, the model is fitted once with default settings.
 #' @param tuning_strategy A string specifying the tuning strategy ("grid", "bayes", or "none"), possibly with adaptive methods.
 #' @param tuning_iterations Number of iterations for iterative tuning methods.
 #' @param early_stopping Logical for early stopping in Bayesian tuning.
@@ -264,16 +264,14 @@ train_models <- function(train_data,
         }
       }
 
-      if(algo == "logistic_reg" && engine %in% c("glm", "gee" ,"glmer" , "stan" , "stan_glmer")){
-
-        perform_tuning = FALSE
-      }else{
-
-      perform_tuning <- !all(vapply(engine_tune_params, is.null, logical(1))) && !is.null(resamples)
-
-      if (tuning_strategy == "none") {
+      if (algo == "logistic_reg" && engine %in% c("glm", "gee", "glmer", "stan", "stan_glmer")) {
         perform_tuning <- FALSE
-      }
+      } else {
+        has_custom <- !is.null(user_params)
+        perform_tuning <- (use_default_tuning || has_custom) && !is.null(resamples)
+        if (tuning_strategy == "none") {
+          perform_tuning <- FALSE
+        }
       }
 
        # For other algorithms, use a switch that uses the current engine

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -96,8 +96,9 @@ Default is \code{"error"}.}
 \item{scaling_methods}{Vector of scaling methods to apply. Default is \code{c("center", "scale")}.}
 
 \item{summaryFunction}{A custom summary function for model evaluation. Default is \code{NULL}.}
+\item{use_default_tuning}{Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, models are fitted once with default settings. Default is \code{FALSE}.}
 
-\item{use_default_tuning}{Logical indicating whether to use default tuning grids when \code{tune_params} is \code{NULL}. Default is \code{FALSE}.}
+
 
 \item{tuning_strategy}{A string specifying the tuning strategy. Options might include \code{"grid"}, \code{"bayes"}, or \code{"none"}. If \code{"none"} is used, the workflow is fitted directly without tuning. Default is \code{"grid"}.}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -50,7 +50,7 @@ train_models(
 
 \item{recipe}{A recipe object for preprocessing.}
 
-\item{use_default_tuning}{Logical indicating whether to use default tuning grids when \code{tune_params} is \code{NULL}.}
+\item{use_default_tuning}{Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, the model is fitted once with default settings. Default is \code{FALSE}.}
 
 \item{tuning_strategy}{A string specifying the tuning strategy ("grid", "bayes", or "none"), possibly with adaptive methods. If set to \code{"none"}, the workflow is fitted directly without tuning.}
 


### PR DESCRIPTION
## Summary
- update `use_default_tuning` docs
- tune only if default grids requested or custom parameters supplied
- document new behavior in Rd files

## Testing
- `R CMD check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851227d323c832aaf1a36d3d88fcc2b