### PR TITLE
Improve tuning param interaction

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -58,6 +58,11 @@ train_models <- function(train_data,
 
   set.seed(seed)
 
+  if (tuning_strategy == "bayes" && adaptive) {
+    warning("'adaptive' is not supported with Bayesian tuning. Setting adaptive = FALSE.")
+    adaptive <- FALSE
+  }
+
   if (task == "classification") {
 
     if(is.null(summaryFunction)){

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -106,7 +106,7 @@ Default is \code{"error"}.}
 
 \item{early_stopping}{Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.}
 
-\item{adaptive}{Logical indicating whether to use adaptive/racing methods for tuning. Default is \code{FALSE}.}
+\item{adaptive}{Logical indicating whether to use adaptive/racing methods for tuning. If \code{tuning_strategy = "bayes"}, this option is ignored with a warning. Default is \code{FALSE}.}
 
 \item{learning_curve}{Logical. If TRUE, generate learning curves (performance vs. training size).}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -58,7 +58,7 @@ train_models(
 
 \item{early_stopping}{Logical for early stopping in Bayesian tuning.}
 
-\item{adaptive}{Logical indicating whether to use adaptive/racing methods.}
+\item{adaptive}{Logical indicating whether to use adaptive/racing methods. If \code{tuning_strategy = "bayes"}, this option is ignored with a warning.}
 
 \item{algorithm_engines}{A named list specifying the engine to use for each algorithm.}
 }


### PR DESCRIPTION
## Summary
- guard against using `adaptive` with Bayesian tuning
- document that adaptive tuning is ignored with Bayesian search

## Testing
- `R CMD build .`
- `R CMD check fastml_0.6.1.tar.gz` *(fails: unable to access cloud.r-project.org)*

------
https://chatgpt.com/codex/tasks/task_e_6851325aad0c832ab8373ca18defcacc