### PR TITLE
Add tuning_strategy validation

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -49,7 +49,8 @@ utils::globalVariables(c("Fraction", "Performance"))
 #' @param scaling_methods Vector of scaling methods to apply. Default is \code{c("center", "scale")}.
 #' @param summaryFunction A custom summary function for model evaluation. Default is \code{NULL}.
 #' @param use_default_tuning Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, models are fitted once with default settings. Default is \code{FALSE}.
-#' @param tuning_strategy A string specifying the tuning strategy. Options might include \code{"grid"}, \code{"bayes"}, or \code{"none"}. Default is \code{"grid"}.
+#' @param tuning_strategy A string specifying the tuning strategy. Must be one of
+#'   \code{"grid"}, \code{"bayes"}, or \code{"none"}. Default is \code{"grid"}.
 #' @param tuning_iterations Number of tuning iterations (applicable for Bayesian or other iterative search methods). Default is \code{10}.
 #' @param early_stopping Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.
 #' @param adaptive Logical indicating whether to use adaptive/racing methods for tuning. Default is \code{FALSE}.
@@ -132,6 +133,7 @@ fastml <- function(data = NULL,
   set.seed(seed)
 
   task <- match.arg(task, c("auto", "classification", "regression"))
+  tuning_strategy <- match.arg(tuning_strategy, c("grid", "bayes", "none"))
 
   # If explicit train/test provided, ensure both are given
   if (!is.null(train_data) || !is.null(test_data)) {

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -18,7 +18,10 @@
 #' @param seed An integer value specifying the random seed for reproducibility.
 #' @param recipe A recipe object for preprocessing.
 #' @param use_default_tuning Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, the model is fitted once with default settings.
-#' @param tuning_strategy A string specifying the tuning strategy ("grid", "bayes", or "none"), possibly with adaptive methods.
+#' @param tuning_strategy A string specifying the tuning strategy. Must be one of
+#'   \code{"grid"}, \code{"bayes"}, or \code{"none"}. Adaptive methods may be
+#'   used with \code{"grid"}. If \code{"none"} is selected, the workflow is fitted
+#'   directly without tuning.
 #' @param tuning_iterations Number of iterations for iterative tuning methods.
 #' @param early_stopping Logical for early stopping in Bayesian tuning.
 #' @param adaptive Logical indicating whether to use adaptive/racing methods.
@@ -57,6 +60,8 @@ train_models <- function(train_data,
                          algorithm_engines = NULL) {
 
   set.seed(seed)
+
+  tuning_strategy <- match.arg(tuning_strategy, c("grid", "bayes", "none"))
 
   if (tuning_strategy == "bayes" && adaptive) {
     warning("'adaptive' is not supported with Bayesian tuning. Setting adaptive = FALSE.")

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -100,7 +100,7 @@ Default is \code{"error"}.}
 
 
 
-\item{tuning_strategy}{A string specifying the tuning strategy. Options might include \code{"grid"}, \code{"bayes"}, or \code{"none"}. If \code{"none"} is used, the workflow is fitted directly without tuning. Default is \code{"grid"}.}
+\item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. If \code{"none"} is used, the workflow is fitted directly without tuning. Default is \code{"grid"}.}
 
 \item{tuning_iterations}{Number of tuning iterations (applicable for Bayesian or other iterative search methods). Default is \code{10}.}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -52,7 +52,7 @@ train_models(
 
 \item{use_default_tuning}{Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, the model is fitted once with default settings. Default is \code{FALSE}.}
 
-\item{tuning_strategy}{A string specifying the tuning strategy ("grid", "bayes", or "none"), possibly with adaptive methods. If set to \code{"none"}, the workflow is fitted directly without tuning.}
+\item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. Adaptive methods may be used with \code{"grid"}. If set to \code{"none"}, the workflow is fitted directly without tuning.}
 
 \item{tuning_iterations}{Number of iterations for iterative tuning methods.}
 

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -235,3 +235,15 @@ test_that("stop if unsupported metric is selected.", {
   })
 })
 
+test_that("invalid tuning_strategy triggers error", {
+  expect_error(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      tuning_strategy = "invalid"
+    ),
+    "should be one of"
+  )
+})
+


### PR DESCRIPTION
## Summary
- check `tuning_strategy` in `fastml` and `train_models`
- document allowed options in Rd files
- test invalid `tuning_strategy` errors

## Testing
- `R -q -e "library(testthat); testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_6851421bdd88832abfc8f31723bda168