### PR TITLE
Improve tuning docs and tests

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -51,7 +51,8 @@ utils::globalVariables(c("Fraction", "Performance"))
 #' @param use_default_tuning Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, models are fitted once with default settings. Default is \code{FALSE}.
 #' @param tuning_strategy A string specifying the tuning strategy. Must be one of
 #'   \code{"grid"}, \code{"bayes"}, or \code{"none"}. Default is \code{"grid"}.
-#' @param tuning_iterations Number of tuning iterations (applicable for Bayesian or other iterative search methods). Default is \code{10}.
+#' @param tuning_iterations Number of iterations for Bayesian tuning. Ignored when
+#'   \code{tuning_strategy} is not \code{"bayes"}. Default is \code{10}.
 #' @param early_stopping Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.
 #' @param adaptive Logical indicating whether to use adaptive/racing methods for tuning. Default is \code{FALSE}.
 #' @param learning_curve Logical. If TRUE, generate learning curves (performance vs. training size).

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -22,7 +22,8 @@
 #'   \code{"grid"}, \code{"bayes"}, or \code{"none"}. Adaptive methods may be
 #'   used with \code{"grid"}. If \code{"none"} is selected, the workflow is fitted
 #'   directly without tuning.
-#' @param tuning_iterations Number of iterations for iterative tuning methods.
+#' @param tuning_iterations Number of iterations for Bayesian tuning. Ignored
+#'   when \code{tuning_strategy} is not \code{"bayes"}.
 #' @param early_stopping Logical for early stopping in Bayesian tuning.
 #' @param adaptive Logical indicating whether to use adaptive/racing methods.
 #' @param algorithm_engines A named list specifying the engine to use for each algorithm.

--- a/README.md
+++ b/README.md
@@ -53,4 +53,12 @@ model <- fastml(
 summary(model)
 ```
 
+## Tuning Strategies
+
+fastml supports both grid search and Bayesian optimization through the
+`tuning_strategy` argument. Use `"grid"` for a regular parameter grid or
+`"bayes"` for Bayesian hyperparameter search. The `tuning_iterations`
+parameter controls the number of iterations **only** when
+`tuning_strategy = "bayes"` and is ignored otherwise.
+
 

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -102,7 +102,7 @@ Default is \code{"error"}.}
 
 \item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. If \code{"none"} is used, the workflow is fitted directly without tuning. Default is \code{"grid"}.}
 
-\item{tuning_iterations}{Number of tuning iterations (applicable for Bayesian or other iterative search methods). Default is \code{10}.}
+\item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}. Default is \code{10}.}
 
 \item{early_stopping}{Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -54,7 +54,7 @@ train_models(
 
 \item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. Adaptive methods may be used with \code{"grid"}. If set to \code{"none"}, the workflow is fitted directly without tuning.}
 
-\item{tuning_iterations}{Number of iterations for iterative tuning methods.}
+\item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}.}
 
 \item{early_stopping}{Logical for early stopping in Bayesian tuning.}
 

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -247,3 +247,32 @@ test_that("invalid tuning_strategy triggers error", {
   )
 })
 
+test_that("grid tuning executes successfully", {
+  res <- fastml(
+    data = iris,
+    label = "Species",
+    algorithms = c("rand_forest"),
+    use_default_tuning = TRUE,
+    tuning_strategy = "grid",
+    resampling_method = "cv",
+    folds = 2
+  )
+  expect_s3_class(res, "fastml")
+  expect_true(length(res$models) > 0)
+})
+
+test_that("Bayesian tuning executes successfully", {
+  res <- fastml(
+    data = iris,
+    label = "Species",
+    algorithms = c("rand_forest"),
+    use_default_tuning = TRUE,
+    tuning_strategy = "bayes",
+    tuning_iterations = 2,
+    resampling_method = "cv",
+    folds = 2
+  )
+  expect_s3_class(res, "fastml")
+  expect_true(length(res$models) > 0)
+})
+


### PR DESCRIPTION
## Summary
- clarify that `tuning_iterations` only applies to Bayesian tuning
- document tuning strategies in README
- add tests to exercise grid and Bayesian modes

## Testing
- `apt-get update`
- `apt-get install -y r-base`
- `R -q -e "devtools::test()"` *(fails: there is no package called 'devtools')*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_685143bbfab0832a89471c49519fa68f