### PR TITLE
Fix tuning helpers and add coverage

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -69,6 +69,15 @@ train_models <- function(train_data,
     adaptive <- FALSE
   }
 
+  if (!is.numeric(tuning_iterations) || length(tuning_iterations) != 1 ||
+      tuning_iterations <= 0 || tuning_iterations != as.integer(tuning_iterations)) {
+    stop("'tuning_iterations' must be a positive integer")
+  }
+
+  if (early_stopping && tuning_strategy != "bayes") {
+    warning("'early_stopping' is ignored when tuning_strategy is not 'bayes'")
+  }
+
   if (task == "classification") {
 
     if(is.null(summaryFunction)){
@@ -155,6 +164,10 @@ train_models <- function(train_data,
     stop("Unsupported resampling method.")
   }
 
+  if (use_default_tuning && is.null(resamples)) {
+    warning("Tuning is skipped because resampling is disabled")
+  }
+
   models <- list()
 
   # A helper function to choose the engine for an algorithm
@@ -218,8 +231,7 @@ train_models <- function(train_data,
         param_obj %>% dials::range_set(c(new_lb, new_ub))
       })
 
-      params_model <- params_model %>%
-        dplyr::mutate(object = if_else(id == param_name, list(updated_obj), object))
+      params_model$object[params_model$id == param_name] <- list(updated_obj)
     }
     return(params_model)
   }

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -276,3 +276,63 @@ test_that("Bayesian tuning executes successfully", {
   expect_true(length(res$models) > 0)
 })
 
+test_that("adaptive tuning executes successfully", {
+  res <- fastml(
+    data = iris,
+    label = "Species",
+    algorithms = c("rand_forest"),
+    use_default_tuning = TRUE,
+    tuning_strategy = "grid",
+    adaptive = TRUE,
+    resampling_method = "cv",
+    folds = 2
+  )
+  expect_s3_class(res, "fastml")
+})
+
+test_that("warning when early_stopping ignored", {
+  expect_warning(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      use_default_tuning = TRUE,
+      tuning_strategy = "grid",
+      early_stopping = TRUE,
+      resampling_method = "cv",
+      folds = 2
+    ),
+    "early_stopping"
+  )
+})
+
+test_that("early stopping with bayesian tuning works", {
+  res <- fastml(
+    data = iris,
+    label = "Species",
+    algorithms = c("rand_forest"),
+    use_default_tuning = TRUE,
+    tuning_strategy = "bayes",
+    tuning_iterations = 2,
+    early_stopping = TRUE,
+    resampling_method = "cv",
+    folds = 2
+  )
+  expect_s3_class(res, "fastml")
+})
+
+test_that("invalid tuning_iterations triggers error", {
+  expect_error(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      tuning_strategy = "bayes",
+      tuning_iterations = 0,
+      resampling_method = "cv",
+      folds = 2
+    ),
+    "tuning_iterations"
+  )
+})
+


### PR DESCRIPTION
## Summary
- fix update_params for list columns
- warn when early stopping is ignored
- validate `tuning_iterations`
- warn when tuning is disabled with `resampling_method = 'none'`
- add regression tests for adaptive tuning, early stopping, and invalid tuning iterations

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_685145bc548c832ab5b1bda1719048b0