### PR TITLE
Improve tuning validation and warnings

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -51,8 +51,11 @@ utils::globalVariables(c("Fraction", "Performance"))
 #' @param use_default_tuning Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, models are fitted once with default settings. Default is \code{FALSE}.
 #' @param tuning_strategy A string specifying the tuning strategy. Must be one of
 #'   \code{"grid"}, \code{"bayes"}, or \code{"none"}. Default is \code{"grid"}.
+#'   If custom \code{tune_params} are provided while \code{tuning_strategy = "none"},
+#'   they will be ignored with a warning.
 #' @param tuning_iterations Number of iterations for Bayesian tuning. Ignored when
-#'   \code{tuning_strategy} is not \code{"bayes"}. Default is \code{10}.
+#'   \code{tuning_strategy} is not \code{"bayes"}. Validation of this argument only
+#'   occurs for the Bayesian strategy. Default is \code{10}.
 #' @param early_stopping Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.
 #' @param adaptive Logical indicating whether to use adaptive/racing methods for tuning. Default is \code{FALSE}.
 #' @param learning_curve Logical. If TRUE, generate learning curves (performance vs. training size).

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -22,8 +22,11 @@
 #'   \code{"grid"}, \code{"bayes"}, or \code{"none"}. Adaptive methods may be
 #'   used with \code{"grid"}. If \code{"none"} is selected, the workflow is fitted
 #'   directly without tuning.
+#'   If custom \code{tune_params} are supplied with \code{tuning_strategy = "none"},
+#'   they will be ignored with a warning.
 #' @param tuning_iterations Number of iterations for Bayesian tuning. Ignored
-#'   when \code{tuning_strategy} is not \code{"bayes"}.
+#'   when \code{tuning_strategy} is not \code{"bayes"}; validation occurs only
+#'   for the Bayesian strategy.
 #' @param early_stopping Logical for early stopping in Bayesian tuning.
 #' @param adaptive Logical indicating whether to use adaptive/racing methods.
 #' @param algorithm_engines A named list specifying the engine to use for each algorithm.
@@ -69,9 +72,15 @@ train_models <- function(train_data,
     adaptive <- FALSE
   }
 
-  if (!is.numeric(tuning_iterations) || length(tuning_iterations) != 1 ||
-      tuning_iterations <= 0 || tuning_iterations != as.integer(tuning_iterations)) {
-    stop("'tuning_iterations' must be a positive integer")
+  if (tuning_strategy == "none" && !is.null(tune_params)) {
+    warning("'tune_params' are ignored when 'tuning_strategy' is 'none'")
+  }
+
+  if (tuning_strategy == "bayes") {
+    if (!is.numeric(tuning_iterations) || length(tuning_iterations) != 1 ||
+        tuning_iterations <= 0 || tuning_iterations != as.integer(tuning_iterations)) {
+      stop("'tuning_iterations' must be a positive integer")
+    }
   }
 
   if (early_stopping && tuning_strategy != "bayes") {

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -100,9 +100,9 @@ Default is \code{"error"}.}
 
 
 
-\item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. If \code{"none"} is used, the workflow is fitted directly without tuning. Default is \code{"grid"}.}
+\item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. If \code{"none"} is used, the workflow is fitted directly without tuning. If custom \code{tune\_params} are provided in this mode, they will be ignored with a warning. Default is \code{"grid"}.}
 
-\item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}. Default is \code{10}.}
+\item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}. Validation of this argument only occurs for the Bayesian strategy. Default is \code{10}.}
 
 \item{early_stopping}{Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -52,9 +52,9 @@ train_models(
 
 \item{use_default_tuning}{Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, the model is fitted once with default settings. Default is \code{FALSE}.}
 
-\item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. Adaptive methods may be used with \code{"grid"}. If set to \code{"none"}, the workflow is fitted directly without tuning.}
+\item{tuning_strategy}{A string specifying the tuning strategy. Must be one of \code{"grid"}, \code{"bayes"}, or \code{"none"}. Adaptive methods may be used with \code{"grid"}. If set to \code{"none"}, the workflow is fitted directly without tuning. If custom \code{tune\_params} are supplied when \code{tuning\_strategy = "none"}, they will be ignored with a warning.}
 
-\item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}.}
+\item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}. Validation of this argument occurs only for the Bayesian strategy.}
 
 \item{early_stopping}{Logical for early stopping in Bayesian tuning.}
 

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -336,3 +336,61 @@ test_that("invalid tuning_iterations triggers error", {
   )
 })
 
+test_that("tuning_iterations ignored for non-bayesian strategies", {
+  expect_no_error(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      use_default_tuning = TRUE,
+      tuning_strategy = "grid",
+      tuning_iterations = 0,
+      resampling_method = "cv",
+      folds = 2
+    )
+  )
+  expect_no_error(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      tuning_strategy = "none",
+      tuning_iterations = -1,
+      resampling_method = "none"
+    )
+  )
+})
+
+test_that("adaptive ignored with bayesian tuning", {
+  expect_warning(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      use_default_tuning = TRUE,
+      tuning_strategy = "bayes",
+      adaptive = TRUE,
+      tuning_iterations = 1,
+      resampling_method = "cv",
+      folds = 2
+    ),
+    "adaptive"
+  )
+})
+
+test_that("warning when tune_params ignored with no tuning", {
+  tune <- list(rand_forest = list(ranger = list(mtry = c(1, 2))))
+  expect_warning(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      tune_params = tune,
+      tuning_strategy = "none",
+      use_default_tuning = TRUE,
+      resampling_method = "none"
+    ),
+    "tune_params"
+  )
+})
+


### PR DESCRIPTION
## Summary
- warn when `tune_params` are provided but `tuning_strategy = "none"`
- validate `tuning_iterations` only for Bayesian tuning
- document new behaviours
- test adaptive warning with Bayesian tuning and new edge cases

## Testing
- `devtools::document()` *(fails: R not installed)*
- `devtools::test()` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685148899d4c832a91c19e823c06dcb3