### PR TITLE
Add verbose option for progress messages

### DIFF
--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -34,7 +34,8 @@ fastml(
   early_stopping = FALSE,
   adaptive = FALSE,
   learning_curve = FALSE,
-  seed = 123
+  seed = 123,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -111,6 +112,8 @@ Default is \code{"error"}.}
 \item{learning_curve}{Logical. If TRUE, generate learning curves (performance vs. training size).}
 
 \item{seed}{An integer value specifying the random seed for reproducibility.}
+
+\item{verbose}{Logical; if TRUE, prints progress messages during the training and evaluation process.}
 }
 \value{
 An object of class \code{fastml} containing the best model, performance metrics, and other information.


### PR DESCRIPTION
## Summary
- add optional `verbose` argument to `fastml`
- document new argument
- print informative messages about splitting, recipe creation, training, evaluation and best model

## Testing
- `R -q -e 'print("hello")'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514e538004832aa46f9d95a529feb6