### PR TITLE
Fix default parameter for SVM RBF

### DIFF
--- a/R/params_helpers.R
+++ b/R/params_helpers.R
@@ -239,7 +239,7 @@ get_default_params <- function(algo, task, num_predictors = NULL, engine = NULL)
          # 11. SVM Radial
          "svm_rbf" = list(
            cost = 1,
-           rbf_sigma = c(-5, -1)
+           rbf_sigma = 0.1
          ),
          # 12. nearest_neighbor
          "nearest_neighbor" = list(


### PR DESCRIPTION
## Summary
- correct `svm_rbf` default parameter so rbf_sigma is numeric

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_68515cf87568832aa6ea471e9fe007a5