### PR TITLE
Enhance fastml with imbalance handling and early stopping

### DIFF
--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -95,6 +95,8 @@ Default is \code{"error"}.}
 \item{encode_categoricals}{Logical indicating whether to encode categorical variables. Default is \code{TRUE}.}
 
 \item{scaling_methods}{Vector of scaling methods to apply. Default is \code{c("center", "scale")}.}
+\item{balance_method}{Method to handle class imbalance. One of \code{"none"}, \code{"upsample"}, or \code{"downsample"}. Default is \code{"none"}.}
+\item{resamples}{Optional rsample object with custom resampling splits. Overrides \code{resampling_method}, \code{folds}, and \code{repeats}.}
 
 \item{summaryFunction}{A custom summary function for model evaluation. Default is \code{NULL}.}
 \item{use_default_tuning}{Logical; if \code{TRUE} and \code{tune_params} is \code{NULL}, tuning is performed using default grids. Tuning also occurs when custom \code{tune_params} are supplied. When \code{FALSE} and no custom parameters are given, models are fitted once with default settings. Default is \code{FALSE}.}
@@ -105,7 +107,7 @@ Default is \code{"error"}.}
 
 \item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}. Validation of this argument only occurs for the Bayesian strategy. Default is \code{10}.}
 
-\item{early_stopping}{Logical indicating whether to use early stopping in Bayesian tuning methods (if supported). Default is \code{FALSE}.}
+\item{early_stopping}{Logical enabling engine-level early stopping when supported. Default is \code{FALSE}.}
 
 \item{adaptive}{Logical indicating whether to use adaptive/racing methods for tuning. If \code{tuning_strategy = "bayes"}, this option is ignored with a warning. Default is \code{FALSE}.}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -39,6 +39,7 @@ train_models(
 \item{folds}{Number of folds for cross-validation.}
 
 \item{repeats}{Number of times to repeat cross-validation (only applicable for methods like "repeatedcv").}
+\item{resamples}{Optional rsample object defining custom resampling splits.}
 
 \item{tune_params}{A named list of tuning ranges for each algorithm and engine pair, e.g. \code{list(rand\_forest = list(ranger = list(mtry = c(1, 3))))}.}
 
@@ -56,7 +57,7 @@ train_models(
 
 \item{tuning_iterations}{Number of iterations for Bayesian tuning. Ignored when \code{tuning_strategy} is not \code{"bayes"}. Validation of this argument occurs only for the Bayesian strategy.}
 
-\item{early_stopping}{Logical for early stopping in Bayesian tuning.}
+\item{early_stopping}{Logical enabling early stopping when supported by the underlying engine.}
 
 \item{adaptive}{Logical indicating whether to use adaptive/racing methods. If \code{tuning_strategy = "bayes"}, this option is ignored with a warning.}
 

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -290,7 +290,7 @@ test_that("adaptive tuning executes successfully", {
   expect_s3_class(res, "fastml")
 })
 
-test_that("warning when early_stopping ignored", {
+test_that("early_stopping does not warn with grid tuning", {
   expect_warning(
     fastml(
       data = iris,
@@ -302,7 +302,7 @@ test_that("warning when early_stopping ignored", {
       resampling_method = "cv",
       folds = 2
     ),
-    "early_stopping"
+    regexp = NA
   )
 })
 


### PR DESCRIPTION
## Summary
- add `balance_method` and `resamples` arguments to `fastml`
- implement up/down sampling for classification training data
- support custom resample objects in `train_models`
- allow engine-level early stopping for boosting algorithms
- adjust documentation and tests accordingly

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851737e38bc832abc0bd467dd96a678