### PR TITLE
Fix DALEX row name warning

### DIFF
--- a/R/explain_dalex.R
+++ b/R/explain_dalex.R
@@ -38,7 +38,9 @@ explain_dalex <- function(object,
   }
 
   train_data <- object$processed_train_data
+  rownames(train_data) <- NULL
   x <- train_data %>% select(-!!label)
+  rownames(x) <- NULL
   y <- train_data[[label]]
 
   positive_class <- NULL


### PR DESCRIPTION
## Summary
- handle row names in DALEX explainer input

## Testing
- `R CMD build .`
- `R CMD check fastml_0.6.1.tar.gz` *(fails: cannot access cloud.r-project.org)*

------
https://chatgpt.com/codex/tasks/task_e_6858f74ebef0832ab7d1bd426d4b4244