### PR TITLE
Fix row name warning in fastexplain

### DIFF
--- a/R/explain_dalex.R
+++ b/R/explain_dalex.R
@@ -37,9 +37,9 @@ explain_dalex <- function(object,
   }
 
   train_data <- object$processed_train_data
-  rownames(train_data) <- NULL
+  rownames(train_data) <- seq_len(nrow(train_data))
   x <- train_data %>% select(-!!label)
-  rownames(x) <- NULL
+  rownames(x) <- seq_len(nrow(x))
   y <- train_data[[label]]
 
   positive_class <- NULL

--- a/tests/testthat/test-fastexplain.R
+++ b/tests/testthat/test-fastexplain.R
@@ -32,3 +32,10 @@ test_that("ICE plot runs", {
 test_that("ALE explanation runs", {
   expect_silent(fastexplain(model, method = "ale", features = "Sepal.Length"))
 })
+
+test_that("DALEX explanation produces no warnings", {
+  expect_warning(
+    fastexplain(model),
+    regexp = NA
+  )
+})


### PR DESCRIPTION
## Summary
- prevent `model_parts` from producing rowname-related warnings by assigning row names to training data before building the DALEX explainer
- add regression test ensuring the DALEX path of `fastexplain()` runs without warnings

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea3215bc8832a98396194bd582bf1