### PR TITLE
Fix DALEX tibble rownames warning

### DIFF
--- a/R/explain_dalex.R
+++ b/R/explain_dalex.R
@@ -36,9 +36,10 @@ explain_dalex <- function(object,
     return(invisible(NULL))
   }
 
-  train_data <- object$processed_train_data
+  train_data <- as.data.frame(object$processed_train_data)
   rownames(train_data) <- seq_len(nrow(train_data))
   x <- train_data %>% select(-!!label)
+  x <- as.data.frame(x)
   rownames(x) <- seq_len(nrow(x))
   y <- train_data[[label]]
 


### PR DESCRIPTION
## Summary
- fix `fastexplain()` by converting tibbles to data.frames before assigning row names

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: could not find function "fastml" and missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_685ea47fee24832a90640ca6c6fde52e