### PR TITLE
fix survival label check in fastml

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -211,7 +211,15 @@ fastml <- function(data = NULL,
 
   # If initial data provided, perform exclusion and checks, then split
   if (!is.null(data)) {
-    if (!(label %in% names(data))) stop("The specified label does not exist in the data.")
+    if (task == "survival") {
+      if (!all(label %in% names(data))) {
+        stop("The specified label(s) do not exist in the data.")
+      }
+    } else {
+      if (!(label %in% names(data))) {
+        stop("The specified label does not exist in the data.")
+      }
+    }
     if (!is.null(exclude)) {
       if (label %in% exclude) stop("Label variable cannot be excluded: ", label)
       missing_vars <- setdiff(exclude, colnames(data))

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -1,10 +1,25 @@
 library(dplyr)
 library(testthat)
+library(survival)
 
 data(iris)
 iris <- iris[iris$Species != "setosa", ]  # Binary classification
 iris$Species <- factor(iris$Species)
 
+
+data(cancer)
+test_that("survival label accepts time and status columns", {
+  expect_error(
+    fastml(
+      data = cancer,
+      label = c("time", "status"),
+      algorithms = c("rand_forest"),
+      task = "survival",
+      test_size = 0.3
+    ),
+    NA
+  )
+})
 
 test_that("'label' is not available in the data", {
   expect_error({


### PR DESCRIPTION
## Summary
- handle survival labels containing both time and status columns
- add regression test ensuring survival models accept two-column label

## Testing
- `R CMD check .` *(fails: Required fields missing or empty: 'Author' 'Maintainer')*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_68c01c12146c832a877f8ad511daa36c