### PR TITLE
Handle MICE imputation for survival tasks

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -417,8 +417,19 @@ fastml <- function(data = NULL,
           # Perform MICE on train_data only. Typically, you do MICE on training and apply
           # some approach to test, but for simplicity, we'll do them separately:
           # 1) For train_data:
-          train_data_mice <- mice(train_data)  # Basic usage
-          train_data <- complete(train_data_mice)
+          train_cols <- names(train_data)
+          matrix_cols_train <- vapply(train_data, is.matrix, logical(1))
+          if (any(matrix_cols_train)) {
+            train_matrix <- train_data[, matrix_cols_train, drop = FALSE]
+            train_non_matrix <- train_data[, !matrix_cols_train, drop = FALSE]
+            train_data_mice <- mice(train_non_matrix)
+            train_non_matrix <- complete(train_data_mice)
+            train_data <- cbind(train_non_matrix, train_matrix)
+            train_data <- train_data[, train_cols]
+          } else {
+            train_data_mice <- mice(train_data)  # Basic usage
+            train_data <- complete(train_data_mice)
+          }
 
           warning("Missing values in the training set have been imputed using the 'mice' method.")
 
@@ -428,8 +439,19 @@ fastml <- function(data = NULL,
           # We'll create a temporary combined approach or re-run MICE on test alone.
           # This is simplistic but workable for demonstration.
           if (anyNA(test_data)) {
-            test_data_mice <- mice(test_data)
-            test_data <- complete(test_data_mice)
+            test_cols <- names(test_data)
+            matrix_cols_test <- vapply(test_data, is.matrix, logical(1))
+            if (any(matrix_cols_test)) {
+              test_matrix <- test_data[, matrix_cols_test, drop = FALSE]
+              test_non_matrix <- test_data[, !matrix_cols_test, drop = FALSE]
+              test_data_mice <- mice(test_non_matrix)
+              test_non_matrix <- complete(test_data_mice)
+              test_data <- cbind(test_non_matrix, test_matrix)
+              test_data <- test_data[, test_cols]
+            } else {
+              test_data_mice <- mice(test_data)
+              test_data <- complete(test_data_mice)
+            }
 
             warning("Missing values in the test set have been imputed using the 'mice' method.")
 

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -21,6 +21,21 @@ test_that("survival label accepts time and status columns", {
   )
 })
 
+test_that("survival task works with mice imputation", {
+  skip_if_not_installed("mice")
+  res <- suppressWarnings(
+    fastml(
+      data = cancer,
+      label = c("time", "status"),
+      algorithms = c("rand_forest"),
+      task = "survival",
+      test_size = 0.3,
+      impute_method = "mice"
+    )
+  )
+  expect_s3_class(res, "fastml")
+})
+
 test_that("'label' is not available in the data", {
   expect_error({
     # Train models with Bayesian optimization


### PR DESCRIPTION
## Summary
- Exclude matrix (e.g. `Surv`) columns from MICE imputation and reattach after completion
- Add test ensuring survival modeling works with MICE-based imputation

## Testing
- `R -q -e "library(testthat); testthat::test_dir('tests/testthat')"` *(fails: there is no package called 'testthat')*
- `R -q -e "install.packages(c('testthat','tidymodels','ranger','mice','missForest'), repos='https://cloud.r-project.org')"` *(fails: unable to access index for repository https://cloud.r-project.org/src/contrib/PACKAGES)*

------
https://chatgpt.com/codex/tasks/task_e_68c01f094868832a85c9b6a5404788ed