### PR TITLE
Ensure survival random forest loads required packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -72,6 +72,7 @@ Suggests:
     xgboost,
     ranger,
     aorsf,
+    censored,
     crayon,
     kernlab,
     klaR,

--- a/R/spec_tree.R
+++ b/R/spec_tree.R
@@ -63,6 +63,12 @@ define_rand_forest_spec <- function(task, train_data, label, tuning = FALSE, eng
     model_spec <- model_spec %>%
       set_engine("spark", seed = 1234)
   } else if (engine == "aorsf") {
+    if (!requireNamespace("censored", quietly = TRUE)) {
+      stop("Package 'censored' is required for the 'aorsf' engine. Please install it.", call. = FALSE)
+    }
+    if (!requireNamespace("aorsf", quietly = TRUE)) {
+      stop("Package 'aorsf' is required for the 'aorsf' engine. Please install it.", call. = FALSE)
+    }
     model_spec <- model_spec %>%
       set_engine("aorsf")
   } else if (engine == "partykit") {

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -9,6 +9,8 @@ iris$Species <- factor(iris$Species)
 
 data(cancer)
 test_that("survival label accepts time and status columns", {
+  skip_if_not_installed("aorsf")
+  skip_if_not_installed("censored")
   expect_error(
     fastml(
       data = cancer,
@@ -26,6 +28,8 @@ test_that("rand_forest defaults to aorsf engine for survival", {
 })
 
 test_that("survival task works with mice imputation", {
+  skip_if_not_installed("aorsf")
+  skip_if_not_installed("censored")
   skip_if_not_installed("mice")
   res <- suppressWarnings(
     fastml(


### PR DESCRIPTION
## Summary
- Check for `censored` and `aorsf` packages when using the `aorsf` engine for survival random forests
- Skip survival tests if these packages are unavailable
- Document `censored` as a suggested dependency

## Testing
- `devtools::test(reporter='summary')` *(fails: missing packages "parsnip", "tune", "workflows", and others)*

------
https://chatgpt.com/codex/tasks/task_e_68c2870852c0832a9b5f19c8702d5aac