### PR TITLE
Fix survival risk predictions for native models

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -193,6 +193,20 @@ process_model <- function(model_obj, model_id, task, test_data, label, event_cla
       )
     }
 
+    pred_predictors <- NULL
+    if (inherits(final_model, "fastml_native_survival")) {
+      pred_predictors <- as.data.frame(pred_new_data)
+      drop_cols <- c(final_model$response, final_model$time_col,
+                     final_model$status_col, final_model$start_col)
+      drop_cols <- unique(drop_cols[!is.na(drop_cols)])
+      drop_cols <- intersect(drop_cols, names(pred_predictors))
+      if (length(drop_cols) > 0) {
+        keep_cols <- setdiff(names(pred_predictors), drop_cols)
+        if (is.null(keep_cols)) keep_cols <- character(0)
+        pred_predictors <- pred_predictors[, keep_cols, drop = FALSE]
+      }
+    }
+
     extract_pred <- function(pred) {
       # Return early if NULL
       if (is.null(pred)) {
@@ -234,9 +248,47 @@ process_model <- function(model_obj, model_id, task, test_data, label, event_cla
 
     risk <- tryCatch({
       if (inherits(final_model, "fastml_native_survival")) {
-        # For coxph objects, use linear predictor
+        # Prepare predictor-only data for native survival fits
+        if (is.null(pred_predictors)) {
+          pred_predictors <- data.frame()
+        }
         if (inherits(final_model$fit, "coxph")) {
-          as.numeric(stats::predict(final_model$fit, newdata = pred_new_data, type = "lp"))
+          as.numeric(stats::predict(final_model$fit, newdata = pred_predictors, type = "lp"))
+        } else if (inherits(final_model$fit, "survreg")) {
+          as.numeric(stats::predict(final_model$fit, newdata = pred_predictors, type = "lp"))
+        } else if (inherits(final_model$fit, "glmnet")) {
+          if (!requireNamespace("glmnet", quietly = TRUE)) {
+            rep(NA_real_, nrow(test_data))
+          } else {
+            feature_names <- final_model$feature_names
+            n_obs <- nrow(pred_predictors)
+            if (is.null(feature_names) || length(feature_names) == 0) {
+              rep(NA_real_, nrow(test_data))
+            } else if (n_obs == 0) {
+              numeric(0)
+            } else {
+              if (ncol(pred_predictors) > 0) {
+                mm <- stats::model.matrix(~ . - 1, data = pred_predictors)
+              } else {
+                mm <- matrix(0, nrow = n_obs, ncol = 0)
+              }
+              mm_full <- matrix(0, nrow = n_obs, ncol = length(feature_names))
+              colnames(mm_full) <- feature_names
+              if (ncol(mm) > 0) {
+                overlap <- intersect(feature_names, colnames(mm))
+                if (length(overlap) > 0) {
+                  mm_full[, overlap, drop = FALSE] <- mm[, overlap, drop = FALSE]
+                }
+              }
+              penalty <- final_model$penalty
+              pred_lp <- glmnet::predict(final_model$fit, newx = mm_full,
+                                         s = penalty, type = "link")
+              if (is.matrix(pred_lp)) {
+                pred_lp <- pred_lp[, 1, drop = TRUE]
+              }
+              as.numeric(pred_lp)
+            }
+          }
         } else {
           rep(NA_real_, nrow(test_data))
         }
@@ -257,11 +309,49 @@ process_model <- function(model_obj, model_id, task, test_data, label, event_cla
       if (inherits(final_model, "fastml_native_survival")) {
         if (requireNamespace("censored", quietly = TRUE)) {
           if (inherits(final_model$fit, "coxph")) {
-            censored::survival_prob_coxph(final_model$fit, pred_new_data, eval_time = t0)
+            censored::survival_prob_coxph(final_model$fit, pred_predictors, eval_time = t0)
           } else if (inherits(final_model$fit, "survreg")) {
-            censored::survival_prob_survreg(final_model$fit, pred_new_data, eval_time = t0)
+            censored::survival_prob_survreg(final_model$fit, pred_predictors, eval_time = t0)
           } else {
             NULL
+          }
+        } else if (inherits(final_model$fit, "coxph") || inherits(final_model$fit, "survreg")) {
+          if (nrow(pred_predictors) == 0) {
+            numeric(0)
+          } else {
+            surv_fit <- tryCatch(
+              survival::survfit(final_model$fit, newdata = pred_predictors),
+              error = function(e) NULL
+            )
+            if (is.null(surv_fit)) {
+              NULL
+            } else {
+              surv_summary_vals <- tryCatch({
+                summary(surv_fit, times = t0, extend = TRUE)$surv
+              }, error = function(e) NULL)
+              if (!is.null(surv_summary_vals) && length(surv_summary_vals) == nrow(pred_predictors)) {
+                as.numeric(surv_summary_vals)
+              } else {
+                surv_times <- surv_fit$time
+                surv_vals <- surv_fit$surv
+                if (length(surv_times) == 0 || is.null(surv_vals)) {
+                  rep(1, nrow(pred_predictors))
+                } else if (is.matrix(surv_vals)) {
+                  idx <- findInterval(t0, surv_times)
+                  as.numeric(apply(surv_vals, 2, function(curve) {
+                    if (idx <= 0) {
+                      1
+                    } else {
+                      curve[min(idx, length(curve))]
+                    }
+                  }))
+                } else {
+                  idx <- findInterval(t0, surv_times)
+                  val <- if (idx <= 0) 1 else surv_vals[min(idx, length(surv_vals))]
+                  rep(val, nrow(pred_predictors))
+                }
+              }
+            }
           }
         } else {
           NULL
@@ -282,13 +372,13 @@ process_model <- function(model_obj, model_id, task, test_data, label, event_cla
     surv_time <- tryCatch({
       if (inherits(final_model, "fastml_native_survival") && requireNamespace("censored", quietly = TRUE)) {
         if (inherits(final_model$fit, "coxph")) {
-          as.numeric(censored::survival_time_coxph(final_model$fit, pred_new_data))
+          as.numeric(censored::survival_time_coxph(final_model$fit, pred_predictors))
         } else if (inherits(final_model$fit, "survbagg")) {
-          as.numeric(censored::survival_time_survbagg(final_model$fit, pred_new_data))
+          as.numeric(censored::survival_time_survbagg(final_model$fit, pred_predictors))
         } else if (inherits(final_model$fit, "mboost")) {
-          as.numeric(censored::survival_time_mboost(final_model$fit, pred_new_data))
+          as.numeric(censored::survival_time_mboost(final_model$fit, pred_predictors))
         } else if (inherits(final_model$fit, "glmnet")) {
-          as.numeric(censored::survival_time_coxnet(final_model$fit, pred_new_data))
+          as.numeric(censored::survival_time_coxnet(final_model$fit, pred_predictors))
         } else {
           rep(NA_real_, nrow(test_data))
         }


### PR DESCRIPTION
## Summary
- reuse preprocessed predictor data for native survival workflows
- compute linear predictors for coxph, survreg, and glmnet-based Cox models, including alignment of glmnet feature columns
- add a survival::survfit fallback for survival probability estimates when censored is unavailable and pass the predictor data to censored helpers

## Testing
- not run (R is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ca96a11610832aaef2e9c25ca4c8b7