### PR TITLE
Fix coxnet risk predictions

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -266,8 +266,23 @@ train_models <- function(train_data,
           warning(sprintf("coxnet final fit failed: %s", glmnet_fit$message))
           next
         }
-        spec <- create_native_spec("coxnet", engine, glmnet_fit, rec_prep,
-                                   extras = list(penalty = lambda, feature_names = colnames(x_mat)))
+        x_terms <- attr(x_mat, "terms")
+        if (!is.null(x_terms)) {
+          attr(x_terms, ".Environment") <- baseenv()
+        }
+        x_contrasts <- attr(x_mat, "contrasts")
+        spec <- create_native_spec(
+          "coxnet",
+          engine,
+          glmnet_fit,
+          rec_prep,
+          extras = list(
+            penalty = lambda,
+            feature_names = colnames(x_mat),
+            x_terms = x_terms,
+            x_contrasts = x_contrasts
+          )
+        )
       } else if (algo == "royston_parmar") {
         if (!requireNamespace("rstpm2", quietly = TRUE)) {
           warning("Package 'rstpm2' not installed; skipping royston_parmar.")


### PR DESCRIPTION
## Summary
- store the glmnet terms and contrast information alongside the coxnet fit so prediction can recreate the training design matrix
- rebuild the coxnet risk scorer to reuse the stored metadata, align columns safely, and fall back to coefficient-based predictions when needed

## Testing
- Rscript /tmp/test_coxnet_debug.R

------
https://chatgpt.com/codex/tasks/task_e_68ca9f19973c832a93653895cb89804d