### PR TITLE
Remove coxnet survival support

### DIFF
--- a/R/engine_helpers.R
+++ b/R/engine_helpers.R
@@ -63,7 +63,6 @@ availableMethods <- function(type = c("classification", "regression", "survival"
         "stratified_cox",
         "time_varying_cox",
         "survreg",
-        "coxnet",
         "royston_parmar"
       )
     }
@@ -100,9 +99,6 @@ get_default_engine <- function(algo, task = NULL) {
   if (algo == "survreg" && !is.null(task) && task == "survival") {
     return("survival")
   }
-  if (algo == "coxnet" && !is.null(task) && task == "survival") {
-    return("glmnet")
-  }
   if (algo == "royston_parmar" && !is.null(task) && task == "survival") {
     return("rstpm2")
   }
@@ -136,7 +132,6 @@ get_default_engine <- function(algo, task = NULL) {
          "stratified_cox" = "survival",
          "time_varying_cox" = "survival",
          "survreg" = "survival",
-         "coxnet" = "glmnet",
          "royston_parmar" = "rstpm2",
          "deep_learning" = "keras",
          stop("No default engine defined for algorithm: ", algo)

--- a/R/process_model.R
+++ b/R/process_model.R
@@ -453,8 +453,6 @@ process_model <- function(model_obj, model_id, task, test_data, label, event_cla
           as.numeric(censored::survival_time_survbagg(final_model$fit, pred_predictors))
         } else if (inherits(final_model$fit, "mboost")) {
           as.numeric(censored::survival_time_mboost(final_model$fit, pred_predictors))
-        } else if (inherits(final_model$fit, "glmnet")) {
-          as.numeric(censored::survival_time_coxnet(final_model$fit, pred_predictors))
         } else {
           rep(NA_real_, nrow(test_data))
         }

--- a/tests/testthat/test-survival.R
+++ b/tests/testthat/test-survival.R
@@ -34,30 +34,6 @@ test_that("cox_ph survival model trains and evaluates", {
   }
 })
 
-test_that("coxnet survival model returns finite risk predictions", {
-  skip_if_not_installed("glmnet")
-  data(cancer, package = "survival")
-  cancer <- cancer[complete.cases(cancer), ]
-  set.seed(42)
-  res <- fastml(
-    data = cancer,
-    label = c("time", "status"),
-    algorithms = "coxnet",
-    task = "survival",
-    resampling_method = "none",
-    test_size = 0.3,
-    metric = "c_index"
-  )
-  expect_s3_class(res, "fastml")
-  perf <- res$performance[[1]]
-  c_index <- perf$.estimate[perf$.metric == "c_index"]
-  expect_equal(length(c_index), 1)
-  expect_true(is.finite(c_index))
-  preds <- res$predictions[[1]]
-  expect_true("risk" %in% names(preds))
-  expect_gt(sum(is.finite(preds$risk)), 0)
-})
-
 test_that("survival random forest with aorsf engine trains when available", {
   skip_if_not_installed("aorsf")
   skip_if_not_installed("censored")


### PR DESCRIPTION
## Summary
- remove the coxnet survival algorithm from the available algorithm list, default engine mapping, and processing pipeline
- delete the coxnet-specific survival training path and related survival-time extraction logic
- drop the coxnet regression test now that the model is no longer supported

## Testing
- Rscript -e 'testthat::test_dir("tests/testthat")' *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caa459ece8832abda39c4f0cd03e9b