### PR TITLE
Fix survreg Brier score computation and royston-parmar training

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -243,10 +243,15 @@ train_models <- function(train_data,
         prep_dat <- get_prepped_data()
         baked_train <- prep_dat$data
         rec_prep <- prep_dat$recipe
-        fit <- tryCatch(rstpm2::stpm2(as.formula(paste(response_col, "~ .")),
-                                      data = baked_train,
-                                      df = 3),
-                        error = function(e) e)
+        fit <- tryCatch({
+          gsm_fn <- get("gsm", envir = asNamespace("rstpm2"))
+          gsm_fn(
+            formula = as.formula(paste(response_col, "~ .")),
+            data = baked_train,
+            df = 3,
+            penalised = FALSE
+          )
+        }, error = function(e) e)
         if (inherits(fit, "error")) {
           warning(sprintf("royston_parmar training failed: %s", fit$message))
           next


### PR DESCRIPTION
## Summary
- add a dedicated path for survreg models that computes survival probabilities with `psurvreg`, enabling Brier scores to be produced
- call `gsm` from the `rstpm2` namespace so the royston_parmar engine no longer fails when the package is installed but not attached
- extend the survival tests to assert that survreg models return finite Brier scores and expose their survival curves

## Testing
- not run (R is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cab7b70d24832ab85c6f0700ea5e3f