### PR TITLE
Fix survival workflows for stratified and Royston-Parmar models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,6 +86,7 @@ Suggests:
     ceterisParibus,
     pdp,
     patchwork,
-    GGally
+    GGally,
+    rstpm2
 RoxygenNote: 7.3.2
 Config/testthat/edition: 3


### PR DESCRIPTION
## Summary
- ensure survival evaluation handles start-stop data, rebuilds strata columns, and supports rstpm2 predictions
- build explicit Surv formulas for Royston-Parmar training and capture default evaluation time
- declare rstpm2 as a suggested dependency

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbeb82f220832a916bee1cc9b51e75