### PR TITLE
Revamp survival metric reporting

### DIFF
--- a/R/model_selection_helpers.R
+++ b/R/model_selection_helpers.R
@@ -129,7 +129,8 @@ get_best_model_idx <- function(df, metric, group_cols = c("Model", "Engine")) {
   group_values <- interaction(df[, group_cols], drop = TRUE)
 
   # Compute the maximum metric for each group
-  if(metric %in% c("rmse", "mae")){
+  lower_is_better <- metric %in% c("rmse", "mae", "ibs") || grepl("^brier_t", metric)
+  if(lower_is_better){
 
     group_val <- ave(metric_values, group_values, FUN = min)
     overall_val <- min(metric_values)

--- a/man/evaluate_models.Rd
+++ b/man/evaluate_models.Rd
@@ -11,7 +11,12 @@ evaluate_models(
   label,
   task,
   metric = NULL,
-  event_class
+  event_class,
+  eval_times = NULL,
+  bootstrap_ci = TRUE,
+  bootstrap_samples = 500,
+  bootstrap_seed = NULL,
+  at_risk_threshold = 0.1
 )
 }
 \arguments{
@@ -30,6 +35,22 @@ columns.}
 \item{metric}{The performance metric to optimize (e.g., "accuracy", "rmse").}
 
 \item{event_class}{A single string. Either "first" or "second" to specify which level of truth to consider as the "event".}
+
+\item{eval_times}{Optional numeric vector of evaluation horizons for survival
+metrics. Passed through to \code{process_model}.}
+
+\item{bootstrap_ci}{Logical indicating whether bootstrap confidence intervals
+should be computed for the evaluation metrics.}
+
+\item{bootstrap_samples}{Number of bootstrap resamples used when
+\code{bootstrap_ci = TRUE}.}
+
+\item{bootstrap_seed}{Optional integer seed for the bootstrap procedure used
+in metric estimation.}
+
+\item{at_risk_threshold}{Minimum proportion of subjects that must remain at
+risk to define \eqn{t_{max}} when computing survival metrics such as the
+integrated Brier score.}
 }
 \value{
 A list with two elements:

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -37,7 +37,12 @@ fastml(
   adaptive = FALSE,
   learning_curve = FALSE,
   seed = 123,
-  verbose = FALSE
+  verbose = FALSE,
+  eval_times = NULL,
+  bootstrap_ci = TRUE,
+  bootstrap_samples = 500,
+  bootstrap_seed = NULL,
+  at_risk_threshold = 0.1
 )
 }
 \arguments{
@@ -137,6 +142,24 @@ occurs for the Bayesian strategy. Default is \code{10}.}
 
 \item{verbose}{Logical; if TRUE, prints progress messages during the training
 and evaluation process.}
+
+\item{eval_times}{Optional numeric vector of evaluation horizons for survival
+models. When \code{NULL}, defaults to the median and 75th percentile of the
+observed follow-up times (rounded to the dataset's time unit).}
+
+\item{bootstrap_ci}{Logical indicating whether bootstrap confidence intervals
+should be computed for performance metrics. Applies to all task types.}
+
+\item{bootstrap_samples}{Integer giving the number of bootstrap resamples to
+use when \code{bootstrap_ci = TRUE}. Defaults to 500.}
+
+\item{bootstrap_seed}{Optional seed passed to the bootstrap procedure used to
+estimate confidence intervals.}
+
+\item{at_risk_threshold}{Numeric value between 0 and 1 used for survival
+metrics to determine the last follow-up time (\eqn{t_{max}}). The maximum time
+is set to the largest observed time where at least this proportion of subjects
+remain at risk.}
 }
 \value{
 An object of class \code{fastml} containing the best model, performance metrics, and other information.

--- a/tests/testthat/test-survival.R
+++ b/tests/testthat/test-survival.R
@@ -23,11 +23,19 @@ test_that("cox_ph survival model trains and evaluates", {
   expect_s3_class(res, "fastml")
   # Ensure performance contains survival metrics
   perf <- res$performance[[1]]
-  expect_true(all(c("c_index", "brier_score", "logrank_p") %in% perf$.metric))
-  brier_val <- perf$.estimate[perf$.metric == "brier_score"]
+  expect_true(all(c("c_index", "uno_c", "ibs", "rmst_diff") %in% perf$.metric))
+  expect_true(all(c(".lower", ".upper", ".n_boot") %in% names(perf)))
+  brier_metrics <- perf$.metric[grepl("^brier_t", perf$.metric)]
+  expect_true(length(brier_metrics) >= 1)
+  brier_val <- perf$.estimate[perf$.metric %in% brier_metrics]
   expect_true(length(brier_val) > 0)
   expect_true(all(is.finite(brier_val)))
   expect_true(all(brier_val >= 0 & brier_val <= 1))
+  ibs_val <- perf$.estimate[perf$.metric == "ibs"]
+  expect_true(all(is.finite(ibs_val)))
+  expect_true(all(ibs_val >= 0 & ibs_val <= 1))
+  expect_true(length(res$survival_brier_times) >= 1)
+  expect_true(all(names(res$survival_brier_times) %in% brier_metrics))
   expect_identical(res$engine_names$cox_ph, "survival")
   # Summary should not error and should print
   expect_no_error(capture.output(summary(res)))
@@ -61,8 +69,10 @@ test_that("survreg survival model returns Brier scores", {
   )
   expect_s3_class(res, "fastml")
   perf <- res$performance[[1]]
-  expect_true(all(c("c_index", "brier_score", "logrank_p") %in% perf$.metric))
-  brier_val <- perf$.estimate[perf$.metric == "brier_score"]
+  expect_true(all(c("c_index", "uno_c", "ibs", "rmst_diff") %in% perf$.metric))
+  brier_metrics <- perf$.metric[grepl("^brier_t", perf$.metric)]
+  expect_true(length(brier_metrics) >= 1)
+  brier_val <- perf$.estimate[perf$.metric %in% brier_metrics]
   expect_true(length(brier_val) > 0)
   expect_true(all(is.finite(brier_val)))
   expect_true(all(brier_val >= 0 & brier_val <= 1))
@@ -89,15 +99,19 @@ test_that("survival random forest with aorsf engine trains when available", {
   pf <- res$performance[[nm]]
   if (is.list(pf)) {
     expect_true("aorsf" %in% names(pf))
-    expect_true(all(c("c_index", "brier_score", "logrank_p") %in% pf$aorsf$.metric))
-    brier_val <- pf$aorsf$.estimate[pf$aorsf$.metric == "brier_score"]
+    expect_true(all(c("c_index", "uno_c", "ibs", "rmst_diff") %in% pf$aorsf$.metric))
+    brier_metrics <- pf$aorsf$.metric[grepl("^brier_t", pf$aorsf$.metric)]
+    expect_true(length(brier_metrics) >= 1)
+    brier_val <- pf$aorsf$.estimate[pf$aorsf$.metric %in% brier_metrics]
     expect_true(length(brier_val) > 0)
     expect_true(all(is.finite(brier_val)))
     expect_true(all(brier_val >= 0 & brier_val <= 1))
   } else {
     # Single engine path
-    expect_true(all(c("c_index", "brier_score", "logrank_p") %in% pf$.metric))
-    brier_val <- pf$.estimate[pf$.metric == "brier_score"]
+    expect_true(all(c("c_index", "uno_c", "ibs", "rmst_diff") %in% pf$.metric))
+    brier_metrics <- pf$.metric[grepl("^brier_t", pf$.metric)]
+    expect_true(length(brier_metrics) >= 1)
+    brier_val <- pf$.estimate[pf$.metric %in% brier_metrics]
     expect_true(length(brier_val) > 0)
     expect_true(all(is.finite(brier_val)))
     expect_true(all(brier_val >= 0 & brier_val <= 1))
@@ -123,8 +137,8 @@ test_that("survival random forest can run with ranger engine when censored is av
   pf <- res$performance[[nm]]
   if (is.list(pf)) {
     expect_true("ranger" %in% names(pf))
-    expect_true(all(c("c_index", "brier_score", "logrank_p") %in% pf$ranger$.metric))
+    expect_true(all(c("c_index", "uno_c", "ibs", "rmst_diff") %in% pf$ranger$.metric))
   } else {
-    expect_true(all(c("c_index", "brier_score", "logrank_p") %in% pf$.metric))
+    expect_true(all(c("c_index", "uno_c", "ibs", "rmst_diff") %in% pf$.metric))
   }
 })


### PR DESCRIPTION
## Summary
- replace the survival evaluation logic with IPCW-based IBS, optional horizon-specific Brier scores, RMST differences, and bootstrap confidence intervals
- add survival metric controls (eval_times, bootstrap settings, at-risk threshold) to the fastml workflow and adjust best-model selection to handle lower-is-better scores
- update summaries, plots, documentation, and survival tests to surface the new metrics and metadata such as dynamic Brier labels and t_max

## Testing
- Not run (R unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd027af440832aa9c30870b57fc602