### PR TITLE
Remove confusion matrix warning for non-classification tasks

### DIFF
--- a/R/summary.fastml.R
+++ b/R/summary.fastml.R
@@ -651,8 +651,6 @@ summary.fastml <- function(object,
       } else {
         cat("\nNo valid predictions to compute confusion matrix.\n\n")
       }
-    } else {
-      cat("\nConfusion matrix is only available for classification tasks.\n\n")
     }
 
   }


### PR DESCRIPTION
## Summary
- remove the message that stated the confusion matrix is only available for classification tasks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd513abf48832a87c6d4441bfeb671