### PR TITLE
Handle stratified Cox summary details

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -607,7 +607,7 @@ fastml <- function(data = NULL,
       recipe <- recipe %>% step_rm(all_of(label_surv))
     }
 
-    # Remove zero-variance predictors
+    # Remove zero-variance predictors before any additional transformations
     recipe <- recipe %>%
       step_zv(all_predictors())
 
@@ -650,6 +650,10 @@ fastml <- function(data = NULL,
     # If encoding needed
     if (encode_categoricals) {
       recipe <- recipe %>% step_dummy(all_nominal_predictors(), -all_outcomes())
+
+      # Encoding can introduce zero-variance predictors (e.g., unused levels),
+      # which would otherwise trigger warnings during subsequent scaling steps.
+      recipe <- recipe %>% step_zv(all_predictors())
     }
 
     # scaling

--- a/R/summary.fastml.R
+++ b/R/summary.fastml.R
@@ -1005,7 +1005,7 @@ summary.fastml <- function(object,
         handled <- FALSE
         success <- FALSE
 
-        if (!is.na(algo_name) && algo_name %in% c("survreg", "cox_ph")) {
+        if (!is.na(algo_name) && algo_name %in% c("survreg", "cox_ph", "stratified_cox")) {
           fit_obj <- extract_survival_fit(label, model_obj)
           if (inherits(fit_obj, "survreg")) {
             success <- isTRUE(print_survreg_details(fit_obj))


### PR DESCRIPTION
## Summary
- ensure the default recipe drops zero-variance predictors created during dummy encoding so downstream scaling no longer raises warnings
- treat `stratified_cox` like other native survival fits when printing summaries so final model details are reported

## Testing
- not run (Rscript is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0fe2fb4f4832a848e04c9e20af658