### PR TITLE
Improve stratified Cox handling and summary

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -248,6 +248,9 @@ process_model <- function(model_obj, model_id, task, test_data, label, event_cla
       if (!is.null(final_model$strata_dummy_cols) && length(final_model$strata_dummy_cols) > 0) {
         keep_cols <- setdiff(keep_cols, final_model$strata_dummy_cols)
       }
+      if (!is.null(final_model$strata_base_cols) && length(final_model$strata_base_cols) > 0) {
+        keep_cols <- setdiff(keep_cols, final_model$strata_base_cols)
+      }
       if (length(keep_cols) == 0) {
         pred_predictors <- pred_predictors[, 0, drop = FALSE]
       } else {


### PR DESCRIPTION
## Summary
- ensure stratified Cox models preserve all stratum levels, remove duplicated predictors, and carry metadata for summaries
- update the survival summary output to omit stratification coefficients, add an explicit strata section, and align concordance with the reported Harrell C-index
- cover the new behaviour with a regression test that validates the printed summary content

## Testing
- not run (R executable not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d1093d85fc832a94f1ba07d4e9fc03