### PR TITLE
Ensure h2o ROC AUC metric retains metric name

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -764,9 +764,10 @@ train_models <- function(train_data,
               yardstick::roc_auc(data, truth = {{truth}}, ...)
             }
 
-            # Assign the same class as roc_auc()
+            # Assign the same metadata as roc_auc() so metric ids stay consistent
             class(roc_auc_h2o) <- class(roc_auc)
-            attr(roc_auc_h2o, "direction") <- "maximize"
+            attr(roc_auc_h2o, "direction") <- attr(yardstick::roc_auc, "direction")
+            attr(roc_auc_h2o, "metric_name") <- attr(yardstick::roc_auc, "metric_name")
 
             my_metrics <- metric_set(accuracy, kap, sens, spec, precision, f_meas, roc_auc_h2o)
 


### PR DESCRIPTION
## Summary
- align the custom h2o roc_auc helper's metadata with yardstick::roc_auc to keep metric identifiers consistent

## Testing
- Rscript -e "devtools::test()" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d24703ef18832aa311107e07af4794