### PR TITLE
Handle time_varying_cox in summary details

### DIFF
--- a/R/summary.fastml.R
+++ b/R/summary.fastml.R
@@ -1141,7 +1141,7 @@ summary.fastml <- function(object,
         handled <- FALSE
         success <- FALSE
 
-        if (!is.na(algo_name) && algo_name %in% c("survreg", "cox_ph", "stratified_cox")) {
+        if (!is.na(algo_name) && algo_name %in% c("survreg", "cox_ph", "stratified_cox", "time_varying_cox")) {
           fit_obj <- extract_survival_fit(label, model_obj)
           if (inherits(fit_obj, "survreg")) {
             success <- isTRUE(print_survreg_details(fit_obj))


### PR DESCRIPTION
## Summary
- treat `time_varying_cox` models like other Cox PH variants when rendering the summary so fitted model statistics can be shown

## Testing
- not run (R is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d249ef8534832a9e50ab64fb3a841c