### PR TITLE
Add engine_params argument for engine-level options

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -33,6 +33,14 @@ utils::globalVariables(c("Fraction", "Performance"))
 #' @param tune_params A named list of tuning ranges for each algorithm and engine
 #'   pair. Example: \code{list(rand_forest = list(ranger = list(mtry = c(1, 3))))}
 #'   will override the defaults for the ranger engine. Default is \code{NULL}.
+#' @param engine_params A named list of engine-level arguments to pass directly
+#'   to the underlying model fitting functions. Use this for fixed settings that
+#'   should apply whenever an engine is fitted (for example,
+#'   \code{list(royston_parmar = list(rstpm2 = list(link = "PO")))},
+#'   \code{list(cox_ph = list(survival = list(ties = "breslow")))}, or
+#'   \code{list(rand_forest = list(ranger = list(importance = "impurity")))}).
+#'   These arguments are distinct from \code{tune_params}, which define ranges of
+#'   hyperparameters to explore during tuning. Default is an empty list.
 #' @param metric The performance metric to optimize during training.
 #' @param algorithm_engines A named list specifying the engine to use for each algorithm.
 #' @param n_cores An integer specifying the number of CPU cores to use for parallel processing. Default is \code{1}.
@@ -145,6 +153,7 @@ fastml <- function(data = NULL,
                    exclude = NULL,
                    recipe = NULL,
                    tune_params = NULL,
+                   engine_params = list(),
                    metric = NULL,
                    algorithm_engines = NULL,
                    n_cores = 1,
@@ -703,6 +712,7 @@ fastml <- function(data = NULL,
     repeats = repeats,
     resamples = resamples,
     tune_params = tune_params,
+    engine_params = engine_params,
     metric = metric,
     summaryFunction = summaryFunction,
     seed = seed,
@@ -896,7 +906,8 @@ fastml <- function(data = NULL,
        folds = folds,
        repeats = repeats,
        resamples = resamples,
-       tune_params = tune_params,
+        tune_params = tune_params,
+        engine_params = engine_params,
         metric = metric,
         summaryFunction = summaryFunction,
         seed = seed,

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -19,6 +19,7 @@ fastml(
   exclude = NULL,
   recipe = NULL,
   tune_params = NULL,
+  engine_params = list(),
   metric = NULL,
   algorithm_engines = NULL,
   n_cores = 1,
@@ -82,6 +83,14 @@ Other options include \code{"none"}, \code{"boot"}, \code{"repeatedcv"}, etc.}
 \item{tune_params}{A named list of tuning ranges for each algorithm and engine
 pair. Example: \code{list(rand_forest = list(ranger = list(mtry = c(1, 3))))}
 will override the defaults for the ranger engine. Default is \code{NULL}.}
+
+\item{engine_params}{A named list of fixed engine-level arguments that are
+passed directly to the underlying fitting call for each algorithm/engine
+combination (e.g. \code{list(royston_parmar = list(rstpm2 = list(link = "PO")))},
+\code{list(cox_ph = list(survival = list(ties = "breslow")))}, or
+\code{list(rand_forest = list(ranger = list(importance = "impurity")))}).
+These values are distinct from \code{tune_params}, which describe ranges for
+hyperparameter tuning.}
 
 \item{metric}{The performance metric to optimize during training.}
 

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -14,6 +14,7 @@ train_models(
   repeats,
   resamples = NULL,
   tune_params,
+  engine_params = list(),
   metric,
   summaryFunction = NULL,
   seed = 123,
@@ -47,6 +48,12 @@ will be used instead of those created internally.}
 \item{tune_params}{A named list of tuning ranges. For each algorithm, supply a
 list of engine-specific parameter values, e.g.
 \code{list(rand_forest = list(ranger = list(mtry = c(1, 3)))).}}
+
+\item{engine_params}{A named list of fixed engine-level arguments supplied
+directly to the underlying model fitting functions for each algorithm and
+engine. Use this for options such as \code{ties = "breslow"} in Cox models or
+\code{importance = "impurity"} for the ranger engine. Unlike
+\code{tune_params}, these values are not tuned.}
 
 \item{metric}{The performance metric to optimize.}
 


### PR DESCRIPTION
## Summary
- add an `engine_params` argument to `fastml()` and `train_models()` so callers can pass fixed engine-level settings
- introduce helpers to merge and resolve engine parameters and pipe them into all survival and parsnip fit calls via `do.call`
- update documentation and add regression tests covering ranger importance and Cox PH tie handling with custom engine parameters

## Testing
- `Rscript -e "devtools::test()"` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f4a80b54832aa6de95ef1c3f3051