### PR TITLE
Sanitize Royston-Parmar summary call output

### DIFF
--- a/R/summary.fastml.R
+++ b/R/summary.fastml.R
@@ -859,112 +859,129 @@ summary.fastml <- function(object,
         return(FALSE)
       }
 
-      format_compact_call <- function(obj) {
-        args_list <- tryCatch(obj@args, error = function(e) NULL)
-        if (is.null(args_list) || length(args_list) == 0) {
-          return(NULL)
-        }
-
-        formula_expr <- tryCatch(args_list$formula, error = function(e) NULL)
-        formula_txt <- NULL
-        if (!is.null(formula_expr)) {
-          formula_txt <- tryCatch(paste(deparse(formula_expr), collapse = " "), error = function(e) NULL)
-        }
-
-        disallowed <- c(
-          "formula", "data", "call", "call.orig", "Call", "call.formula",
-          "mf", "model.frame", "frame", "x", "y", "args", "weights",
-          "offset", "init", "control", "start", "surv", "timeVar",
-          "timePoint", "logH", "linpred", "beta", "gamma", "mle2",
-          "logli", "model"
-        )
-        arg_candidates <- setdiff(names(args_list), disallowed)
-        if (length(arg_candidates) == 0) {
-          arg_candidates <- character()
-        }
-
-        keep_args <- list()
-        for (nm in arg_candidates) {
-          if (!nzchar(nm)) {
-            next
-          }
-          val <- args_list[[nm]]
-          if (is.null(val)) {
-            next
-          }
-          if (is.environment(val) || is.function(val)) {
-            next
-          }
-          if (is.language(val)) {
-            next
-          }
-          if (methods::is(val, "formula")) {
-            next
-          }
-          if (is.list(val) && length(val) > 0 && !all(vapply(val, is.atomic, logical(1)))) {
-            next
-          }
-          keep_args[[nm]] <- val
-        }
-
-        if (length(keep_args) == 0 && is.null(formula_txt)) {
-          return(NULL)
-        }
-
-        if (length(keep_args) > 0) {
-          name_map <- c("penalized" = "penalised", "link.type" = "link")
-          arg_strs <- character()
-          for (nm in names(keep_args)) {
-            label <- if (nm %in% names(name_map)) name_map[[nm]] else nm
-            val_txt <- format_param_value(keep_args[[nm]])
-            arg_strs <- c(arg_strs, paste0(label, " = ", val_txt))
-          }
-        } else {
-          arg_strs <- character()
-        }
-
-        call_components <- c()
-        if (!is.null(formula_txt) && nzchar(formula_txt)) {
-          call_components <- c(call_components, formula_txt)
-        }
-        if (length(arg_strs) > 0) {
-          call_components <- c(call_components, arg_strs)
-        }
-
-        if (length(call_components) == 0) {
-          return(NULL)
-        }
-
-        paste0("stpm2(", paste(call_components, collapse = ", "), ")")
-      }
-
-      collapse_call <- function(call_obj) {
-        call_str <- tryCatch(paste(deparse(call_obj), collapse = " "), error = function(e) "")
-        trimws(call_str)
-      }
-
       extract_call_slot <- function(obj, slot_name) {
+        if (!methods::is(obj, "S4")) {
+          return(NULL)
+        }
         if (!slot_name %in% methods::slotNames(obj)) {
           return(NULL)
         }
         tryCatch(methods::slot(obj, slot_name), error = function(e) NULL)
       }
 
+      gather_call_expression <- function(obj) {
+        call_candidates <- c("call", "call.orig", "Call", "call.formula")
+        for (slot_nm in call_candidates) {
+          expr <- extract_call_slot(obj, slot_nm)
+          if (!is.null(expr) && !is.function(expr)) {
+            return(expr)
+          }
+        }
+        NULL
+      }
+
+      format_clean_stpm2_call <- function(obj) {
+        args_list <- tryCatch(obj@args, error = function(e) NULL)
+        call_expr <- gather_call_expression(obj)
+        call_args <- list()
+        call_arg_names <- character()
+        if (!is.null(call_expr)) {
+          call_args <- as.list(call_expr)
+          if (length(call_args) > 0) {
+            call_args <- call_args[-1]
+            call_arg_names <- names(call_args)
+            if (is.null(call_arg_names)) {
+              call_arg_names <- rep("", length(call_args))
+            }
+          }
+        }
+
+        extract_formula <- function() {
+          candidates <- list(
+            tryCatch(args_list$formula, error = function(e) NULL),
+            if (length(call_args) > 0) {
+              idx <- which(call_arg_names %in% c("", "formula"))
+              if (length(idx) > 0) {
+                call_args[[idx[1]]]
+              } else {
+                NULL
+              }
+            } else {
+              NULL
+            }
+          )
+          for (cand in candidates) {
+            if (!is.null(cand) && !is.function(cand)) {
+              return(cand)
+            }
+          }
+          NULL
+        }
+
+        formula_expr <- extract_formula()
+        formula_txt <- NULL
+        if (!is.null(formula_expr)) {
+          formula_txt <- tryCatch(paste(deparse(formula_expr), collapse = " "), error = function(e) NULL)
+        }
+
+        allowed_args <- c("df", "link", "link.type", "scale", "penalized", "penalised", "cure")
+
+        simple_value <- function(val) {
+          if (is.null(val)) {
+            return(FALSE)
+          }
+          if (is.environment(val) || is.function(val) || is.language(val)) {
+            return(FALSE)
+          }
+          if (methods::is(val, "formula")) {
+            return(FALSE)
+          }
+          if (is.list(val) && !all(vapply(val, is.atomic, logical(1)))) {
+            return(FALSE)
+          }
+          is.atomic(val) && length(val) <= 5
+        }
+
+        get_arg_value <- function(nm) {
+          if (!is.null(args_list) && nm %in% names(args_list)) {
+            return(args_list[[nm]])
+          }
+          if (!is.null(call_args) && nm %in% names(call_args)) {
+            return(call_args[[nm]])
+          }
+          NULL
+        }
+
+        arg_components <- character()
+        for (nm in allowed_args) {
+          val <- get_arg_value(nm)
+          if (!simple_value(val)) {
+            next
+          }
+          label <- if (nm == "link.type") "link" else nm
+          val_txt <- format_param_value(val)
+          if (nzchar(val_txt)) {
+            arg_components <- c(arg_components, paste0(label, " = ", val_txt))
+          }
+        }
+
+        call_parts <- c()
+        if (!is.null(formula_txt) && nzchar(formula_txt)) {
+          call_parts <- c(call_parts, formula_txt)
+        }
+        if (length(arg_components) > 0) {
+          call_parts <- c(call_parts, arg_components)
+        }
+
+        if (length(call_parts) == 0) {
+          return("")
+        }
+        paste0("stpm2(", paste(call_parts, collapse = ", "), ")")
+      }
+
       printed_any <- FALSE
 
-      call_str <- format_compact_call(fit_obj)
-      if (is.null(call_str)) {
-        call_candidates <- c("call", "call.orig", "Call", "call.formula")
-        call_expr <- NULL
-        for (slot_nm in call_candidates) {
-          call_expr <- extract_call_slot(fit_obj, slot_nm)
-          if (!is.null(call_expr) && !is.function(call_expr)) {
-            break
-          }
-          call_expr <- NULL
-        }
-        call_str <- if (!is.null(call_expr)) collapse_call(call_expr) else ""
-      }
+      call_str <- format_clean_stpm2_call(fit_obj)
       if (nzchar(call_str)) {
         cat("  Model call: ", call_str, "\n", sep = "")
         printed_any <- TRUE


### PR DESCRIPTION
## Summary
- ensure Royston–Parmar model summaries emit a clean `stpm2(...)` call without optimizer internals
- extract formula, df, and link safely from the fitted object before printing

## Testing
- `Rscript -e "devtools::test()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ffbaf5fc832a8d07843910f80f1b