### PR TITLE
Improve survival metric handling and flexsurv distribution mapping

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -380,7 +380,8 @@ train_models <- function(train_data,
         dist_arg <- tolower(dist_arg)
         dist_map <- c(
           weibull = "weibull",
-          loglogistic = "loglogistic",
+          loglogistic = "llogis",
+          llogis = "llogis",
           lognormal = "lognormal",
           exponential = "exp",
           exp = "exp"
@@ -388,6 +389,7 @@ train_models <- function(train_data,
         label_map <- c(
           weibull = "weibull",
           loglogistic = "loglogistic",
+          llogis = "loglogistic",
           lognormal = "lognormal",
           exponential = "exponential",
           exp = "exponential"


### PR DESCRIPTION
## Summary
- map user-specified log-logistic distributions to flexsurv's `llogis` name and accept both aliases
- add automatic metric fallback logic so survival runs can select an available metric when the default IBS is absent

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68d53ce8eca0832aaa34b9511d18d84f