### PR TITLE
Ensure flexsurv survival metrics and piecewise exponential setup

### DIFF
--- a/R/flexsurv_utils.R
+++ b/R/flexsurv_utils.R
@@ -61,6 +61,123 @@ fastml_flexsurv_survival_matrix <- function(fit, newdata, times) {
     res
   }
 
+  extract_curves <- function(summary_list, times, n_obs) {
+    if (inherits(summary_list, "data.frame")) {
+      row_cols <- intersect(c(".row", "row", "obs", "case", "id", "ID", "index"),
+                            names(summary_list))
+      if (length(row_cols) > 0) {
+        split_col <- summary_list[[row_cols[1]]]
+        if (!is.null(split_col)) {
+          split_keys <- unique(split_col)
+          split_map <- split(summary_list, split_col)
+          summary_list <- lapply(seq_along(split_keys), function(idx) {
+            key_chr <- as.character(split_keys[idx])
+            if (!is.null(names(split_map)) && key_chr %in% names(split_map)) {
+              df <- split_map[[key_chr]]
+            } else {
+              df <- split_map[[1]]
+            }
+            drop_cols <- intersect(row_cols, names(df))
+            if (length(drop_cols) > 0) {
+              df <- df[, setdiff(names(df), drop_cols), drop = FALSE]
+            }
+            df
+          })
+          summary_list <- unname(summary_list)
+        }
+      }
+    }
+
+    if (!is.list(summary_list)) {
+      summary_list <- list(summary_list)
+    }
+
+    summary_list <- lapply(summary_list, function(df) {
+      if (is.data.frame(df)) {
+        drop_cols <- intersect(c(".row", "row", "obs", "case", "id", "ID", "index"), names(df))
+        if (length(drop_cols) > 0) {
+          df <- df[, setdiff(names(df), drop_cols), drop = FALSE]
+        }
+      }
+      df
+    })
+
+    if (length(summary_list) == 1L && n_obs > 1L) {
+      summary_list <- rep(summary_list, length.out = n_obs)
+    }
+
+    res <- matrix(NA_real_, nrow = n_obs, ncol = length(times))
+
+    max_iter <- min(length(summary_list), n_obs)
+    for (i in seq_len(max_iter)) {
+      df <- summary_list[[i]]
+      if (is.null(df)) {
+        next
+      }
+      time_col <- intersect(c("time", "t", ".eval_time"), names(df))
+      surv_col <- intersect(c("est", "survival", "S", ".pred_survival", ".pred"), names(df))
+      if (length(time_col) == 0 || length(surv_col) == 0) {
+        next
+      }
+      curve_times <- df[[time_col[1]]]
+      curve_surv <- df[[surv_col[1]]]
+      res[i, ] <- align_curve(curve_times, curve_surv, times)
+    }
+
+    if (n_obs > length(summary_list) && length(summary_list) >= 1) {
+      filled <- res[seq_len(max_iter), , drop = FALSE]
+      valid_row <- which(rowSums(!is.na(filled)) > 0)
+      if (length(valid_row) >= 1) {
+        template <- filled[valid_row[1], , drop = TRUE]
+        for (i in seq((max_iter + 1), n_obs)) {
+          res[i, ] <- template
+        }
+      }
+    }
+
+    res <- pmin(pmax(res, 0), 1)
+    res
+  }
+
+  compute_rowwise <- function(newdata, times) {
+    res <- matrix(NA_real_, nrow = nrow(newdata), ncol = length(times))
+    if (nrow(newdata) == 0 || length(times) == 0) {
+      return(res)
+    }
+    for (i in seq_len(nrow(newdata))) {
+      row_df <- newdata[i, , drop = FALSE]
+      row_summary <- tryCatch(
+        flexsurv::summary(
+          fit,
+          type = "survival",
+          t = times,
+          newdata = row_df,
+          ci = FALSE
+        ),
+        error = function(e) NULL
+      )
+      if (is.null(row_summary)) {
+        next
+      }
+      if (is.list(row_summary) && length(row_summary) >= 1) {
+        row_summary <- row_summary[[1]]
+      }
+      if (!is.data.frame(row_summary)) {
+        next
+      }
+      time_col <- intersect(c("time", "t", ".eval_time"), names(row_summary))
+      surv_col <- intersect(c("est", "survival", "S", ".pred_survival", ".pred"), names(row_summary))
+      if (length(time_col) == 0 || length(surv_col) == 0) {
+        next
+      }
+      res[i, ] <- align_curve(row_summary[[time_col[1]]],
+                              row_summary[[surv_col[1]]],
+                              times)
+    }
+    res <- pmin(pmax(res, 0), 1)
+    res
+  }
+
   summary_list <- tryCatch(
     flexsurv::summary(
       fit,
@@ -72,82 +189,18 @@ fastml_flexsurv_survival_matrix <- function(fit, newdata, times) {
     error = function(e) NULL
   )
 
-  if (is.null(summary_list)) {
-    return(NULL)
+  if (!is.null(summary_list)) {
+    res <- extract_curves(summary_list, times, n_obs)
+    has_finite <- any(rowSums(is.finite(res)) > 0)
+    if (!has_finite) {
+      res <- compute_rowwise(newdata, times)
+    }
+  } else {
+    res <- compute_rowwise(newdata, times)
   }
 
-  # Newer versions of flexsurv (and tibbles returned by summary()) sometimes
-  # yield a single data frame with a ".row" (or similar) column instead of a
-  # list of data frames.  Split such outputs so each observation gets its own
-  # curve representation.
-  if (inherits(summary_list, "data.frame")) {
-    row_cols <- intersect(c(".row", "row", "obs", "case"), names(summary_list))
-    if (length(row_cols) > 0) {
-      split_col <- summary_list[[row_cols[1]]]
-      if (!is.null(split_col)) {
-        split_keys <- unique(split_col)
-        split_map <- split(summary_list, split_col)
-        split_names <- names(split_map)
-        summary_list <- lapply(split_keys, function(key) {
-          idx <- match(as.character(key), split_names)
-          map_name <- if (!is.na(idx)) split_names[idx] else split_names[1]
-          df <- split_map[[map_name]]
-          drop_cols <- intersect(row_cols, names(df))
-          if (length(drop_cols) > 0) {
-            df <- df[, setdiff(names(df), drop_cols), drop = FALSE]
-          }
-          df
-        })
-        summary_list <- unname(summary_list)
-      }
-    }
-  }
-
-  if (!is.list(summary_list)) {
-    summary_list <- list(summary_list)
-  }
-
-  summary_list <- lapply(summary_list, function(df) {
-    if (is.data.frame(df)) {
-      drop_cols <- intersect(c(".row", "row", "obs", "case"), names(df))
-      if (length(drop_cols) > 0) {
-        df <- df[, setdiff(names(df), drop_cols), drop = FALSE]
-      }
-    }
-    df
-  })
-
-  if (length(summary_list) == 1L && n_obs > 1L) {
-    summary_list <- rep(summary_list, length.out = n_obs)
-  }
-
-  res <- matrix(NA_real_, nrow = n_obs, ncol = length(times))
-
-  max_iter <- min(length(summary_list), n_obs)
-  for (i in seq_len(max_iter)) {
-    df <- summary_list[[i]]
-    if (is.null(df)) {
-      next
-    }
-    time_col <- intersect(c("time", "t", ".eval_time"), names(df))
-    surv_col <- intersect(c("est", "survival", "S", ".pred_survival", ".pred"), names(df))
-    if (length(time_col) == 0 || length(surv_col) == 0) {
-      next
-    }
-    curve_times <- df[[time_col[1]]]
-    curve_surv <- df[[surv_col[1]]]
-    res[i, ] <- align_curve(curve_times, curve_surv, times)
-  }
-
-  if (n_obs > length(summary_list) && length(summary_list) >= 1) {
-    filled <- res[seq_len(max_iter), , drop = FALSE]
-    valid_row <- which(rowSums(!is.na(filled)) > 0)
-    if (length(valid_row) >= 1) {
-      template <- filled[valid_row[1], , drop = TRUE]
-      for (i in seq((max_iter + 1), n_obs)) {
-        res[i, ] <- template
-      }
-    }
+  if (!all(dim(res) == c(n_obs, length(times)))) {
+    res <- compute_rowwise(newdata, times)
   }
 
   res <- pmin(pmax(res, 0), 1)


### PR DESCRIPTION
## Summary
- make the flexsurv survival matrix helper robust to new summary formats and fall back to per-row evaluation so survival metrics such as IBS are populated
- train the piecewise exponential model with flexsurv's `pwexp` distribution and accept both `breaks` and `cuts` engine parameters

## Testing
- not run (R runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d642666654832a96493a81227a0d3f