### PR TITLE
Improve flexsurv survival predictions

### DIFF
--- a/tests/testthat/test-survival.R
+++ b/tests/testthat/test-survival.R
@@ -172,6 +172,44 @@ test_that("survreg survival model returns Brier scores", {
   expect_true(is.numeric(attr(preds$surv_prob_curve, "eval_times")))
 })
 
+test_that("parametric_surv flexsurv integration returns survival metrics", {
+  skip_if_not_installed("flexsurv")
+
+  data(lung, package = "survival")
+  lung_surv <- subset(lung, select = c(time, status, age, sex, ph.ecog))
+  lung_surv <- stats::na.omit(lung_surv)
+  lung_surv$sex <- factor(lung_surv$sex, levels = 1:2, labels = c("male", "female"))
+
+  set.seed(123)
+  res <- fastml(
+    data = lung_surv,
+    label = c("time", "status"),
+    task = "survival",
+    algorithms = "parametric_surv",
+    metric = "ibs",
+    resampling_method = "none",
+    test_size = 0.30,
+    impute_method = "remove",
+    eval_times = c(90, 180, 365),
+    engine_params = list(
+      parametric_surv = list(
+        flexsurvreg = list(dist = "loglogistic")
+      )
+    )
+  )
+
+  expect_s3_class(res, "fastml")
+  perf <- res$performance[[1]]
+  expect_true(any(perf$.metric == "ibs"))
+  ibs_val <- perf$.estimate[perf$.metric == "ibs"][1]
+  expect_true(is.finite(ibs_val))
+  brier_metrics <- perf$.metric[grepl("^brier_t", perf$.metric)]
+  expect_true(length(brier_metrics) >= 1)
+  brier_vals <- perf$.estimate[perf$.metric %in% brier_metrics]
+  expect_true(all(is.finite(brier_vals)))
+  expect_true(all(brier_vals >= 0 & brier_vals <= 1))
+})
+
 test_that("survival random forest with aorsf engine trains when available", {
   skip_if_not_installed("aorsf")
   skip_if_not_installed("censored")


### PR DESCRIPTION
## Summary
- add a flexsurv::predict-based fallback when constructing survival probability matrices so parametric models yield finite metrics
- cover the parametric_surv loglogistic workflow with a regression test to verify IBS and Brier scores are produced

## Testing
- not run (R packages needed for execution are unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68db8fa2db40832a9b1f8b833d5a2801