### PR TITLE
Add explicit S3 annotations for fastml methods

### DIFF
--- a/R/predict.fastml.R
+++ b/R/predict.fastml.R
@@ -25,6 +25,7 @@
 #' @return A vector of predictions, or a named list of predictions (if multiple models are used).
 #'         If `postprocess_fn` is supplied, its output will be returned instead.
 #'
+#' @method predict fastml
 #' @importFrom stats predict
 #' @importFrom tibble is_tibble
 #' @export

--- a/R/summary.fastml.R
+++ b/R/summary.fastml.R
@@ -42,6 +42,8 @@ utils::globalVariables(c("truth", "residual", "sensitivity", "specificity", "Fal
 #' @param ... Additional arguments.
 #' @return Prints summary of fastml models.
 #'
+#' @method summary fastml
+#'
 #' @importFrom dplyr filter select mutate bind_rows group_by summarise n starts_with distinct
 #' @importFrom magrittr %>%
 #' @importFrom reshape2 melt dcast

--- a/R/xgboost_survival.R
+++ b/R/xgboost_survival.R
@@ -422,6 +422,8 @@ predict_risk <- function(fit, newdata, ...) {
   UseMethod("predict_risk")
 }
 
+#' @rdname predict_risk
+#' @method predict_risk fastml_native_survival
 #' @export
 predict_risk.fastml_native_survival <- function(fit, newdata, ...) {
   if (missing(newdata)) {
@@ -544,6 +546,8 @@ predict_risk.fastml_native_survival <- function(fit, newdata, ...) {
   rep(NA_real_, nrow(predictors))
 }
 
+#' @rdname predict_risk
+#' @method predict_risk workflow
 #' @export
 predict_risk.workflow <- function(fit, newdata, ...) {
   if (missing(newdata)) {
@@ -570,6 +574,8 @@ predict_risk.workflow <- function(fit, newdata, ...) {
   as.numeric(pred_lp)
 }
 
+#' @rdname predict_risk
+#' @method predict_risk default
 #' @export
 predict_risk.default <- function(fit, newdata, ...) {
   stop("predict_risk() is not implemented for objects of class ", paste(class(fit), collapse = ", "), ".")
@@ -627,6 +633,8 @@ fastml_align_survival_output <- function(pred_obj, times, n) {
   stop("Unsupported survival prediction output structure.")
 }
 
+#' @rdname predict_survival
+#' @method predict_survival fastml_native_survival
 #' @export
 predict_survival.fastml_native_survival <- function(fit, newdata, times, ...) {
   if (missing(newdata)) {
@@ -699,6 +707,8 @@ predict_survival.fastml_native_survival <- function(fit, newdata, times, ...) {
   stop("Survival prediction not implemented for this native engine.")
 }
 
+#' @rdname predict_survival
+#' @method predict_survival workflow
 #' @export
 predict_survival.workflow <- function(fit, newdata, times, ...) {
   if (missing(newdata)) {
@@ -722,6 +732,8 @@ predict_survival.workflow <- function(fit, newdata, times, ...) {
   fastml_align_survival_output(pred, times, nrow(newdata))
 }
 
+#' @rdname predict_survival
+#' @method predict_survival default
 #' @export
 predict_survival.default <- function(fit, newdata, times, ...) {
   stop("predict_survival() is not implemented for objects of class ", paste(class(fit), collapse = ", "), ".")


### PR DESCRIPTION
## Summary
- add explicit `@method` tags to `predict.fastml` and `summary.fastml` so roxygen registers the S3 implementations
- document the `predict_risk` and `predict_survival` methods with shared `@rdname` and `@method` annotations to keep the namespace in sync

## Testing
- not run (package dependencies for R CMD check are unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68db928d8964832a9781da180eb669c1