### PR TITLE
Ensure native survival predictor helper is globally available

### DIFF
--- a/R/native_survival_utils.R
+++ b/R/native_survival_utils.R
@@ -1,0 +1,70 @@
+#' Native survival prediction helpers
+#'
+#' The functions in this file provide shared preprocessing logic used across
+#' the package whenever predictions are generated from models that operate on
+#' fastml's "native" survival objects.  They are intentionally kept internal
+#' (not exported) so they can be re-used without polluting the public API.
+#'
+#' @noRd
+NULL
+
+fastml_prepare_native_survival_predictors <- function(model, baked_newdata, original_newdata) {
+  if (is.null(baked_newdata)) {
+    baked_newdata <- data.frame()
+  }
+
+  pred_predictors <- as.data.frame(baked_newdata)
+  keep_cols <- names(pred_predictors)
+
+  drop_cols <- c(model$response, model$time_col, model$status_col, model$start_col)
+  drop_cols <- unique(drop_cols[!is.na(drop_cols)])
+  drop_cols <- intersect(drop_cols, keep_cols)
+  if (length(drop_cols) > 0) {
+    keep_cols <- setdiff(keep_cols, drop_cols)
+  }
+
+  if (!is.null(model$strata_dummy_cols) && length(model$strata_dummy_cols) > 0) {
+    keep_cols <- setdiff(keep_cols, model$strata_dummy_cols)
+  }
+  if (!is.null(model$strata_base_cols) && length(model$strata_base_cols) > 0) {
+    keep_cols <- setdiff(keep_cols, model$strata_base_cols)
+  }
+
+  if (length(keep_cols) == 0) {
+    pred_predictors <- pred_predictors[, 0, drop = FALSE]
+  } else {
+    pred_predictors <- pred_predictors[, keep_cols, drop = FALSE]
+  }
+
+  extra_cols <- unique(c(model$start_col, model$time_col, model$status_col))
+  extra_cols <- extra_cols[!is.na(extra_cols)]
+  if (length(extra_cols) > 0) {
+    for (ec in extra_cols) {
+      if (!(ec %in% names(pred_predictors)) && ec %in% names(original_newdata)) {
+        pred_predictors[[ec]] <- original_newdata[[ec]]
+      }
+    }
+  }
+
+  if (!is.null(model$strata_cols) && length(model$strata_cols) > 0) {
+    strata_levels <- NULL
+    fit_obj <- tryCatch(model$fit, error = function(e) NULL)
+    if (!is.null(fit_obj)) {
+      strata_levels <- tryCatch(fit_obj$xlevels, error = function(e) NULL)
+    }
+    for (sc in model$strata_cols) {
+      if (!(sc %in% names(pred_predictors)) && sc %in% names(original_newdata)) {
+        pred_predictors[[sc]] <- original_newdata[[sc]]
+      }
+      if (sc %in% names(pred_predictors)) {
+        pred_predictors[[sc]] <- as.factor(pred_predictors[[sc]])
+        if (!is.null(strata_levels) && sc %in% names(strata_levels)) {
+          pred_predictors[[sc]] <- factor(pred_predictors[[sc]], levels = strata_levels[[sc]])
+        }
+      }
+    }
+  }
+
+  pred_predictors
+}
+

--- a/R/xgboost_survival.R
+++ b/R/xgboost_survival.R
@@ -7,59 +7,6 @@
 #' @noRd
 NULL
 
-fastml_prepare_native_survival_predictors <- function(model, baked_newdata, original_newdata) {
-  if (is.null(baked_newdata)) {
-    baked_newdata <- data.frame()
-  }
-  pred_predictors <- as.data.frame(baked_newdata)
-  keep_cols <- names(pred_predictors)
-  drop_cols <- c(model$response, model$time_col, model$status_col, model$start_col)
-  drop_cols <- unique(drop_cols[!is.na(drop_cols)])
-  drop_cols <- intersect(drop_cols, keep_cols)
-  if (length(drop_cols) > 0) {
-    keep_cols <- setdiff(keep_cols, drop_cols)
-  }
-  if (!is.null(model$strata_dummy_cols) && length(model$strata_dummy_cols) > 0) {
-    keep_cols <- setdiff(keep_cols, model$strata_dummy_cols)
-  }
-  if (!is.null(model$strata_base_cols) && length(model$strata_base_cols) > 0) {
-    keep_cols <- setdiff(keep_cols, model$strata_base_cols)
-  }
-  if (length(keep_cols) == 0) {
-    pred_predictors <- pred_predictors[, 0, drop = FALSE]
-  } else {
-    pred_predictors <- pred_predictors[, keep_cols, drop = FALSE]
-  }
-  extra_cols <- unique(c(model$start_col, model$time_col, model$status_col))
-  extra_cols <- extra_cols[!is.na(extra_cols)]
-  if (length(extra_cols) > 0) {
-    for (ec in extra_cols) {
-      if (!(ec %in% names(pred_predictors)) && ec %in% names(original_newdata)) {
-        pred_predictors[[ec]] <- original_newdata[[ec]]
-      }
-    }
-  }
-  if (!is.null(model$strata_cols) && length(model$strata_cols) > 0) {
-    strata_levels <- NULL
-    fit_obj <- tryCatch(model$fit, error = function(e) NULL)
-    if (!is.null(fit_obj)) {
-      strata_levels <- tryCatch(fit_obj$xlevels, error = function(e) NULL)
-    }
-    for (sc in model$strata_cols) {
-      if (!(sc %in% names(pred_predictors)) && sc %in% names(original_newdata)) {
-        pred_predictors[[sc]] <- original_newdata[[sc]]
-      }
-      if (sc %in% names(pred_predictors)) {
-        pred_predictors[[sc]] <- as.factor(pred_predictors[[sc]])
-        if (!is.null(strata_levels) && sc %in% names(strata_levels)) {
-          pred_predictors[[sc]] <- factor(pred_predictors[[sc]], levels = strata_levels[[sc]])
-        }
-      }
-    }
-  }
-  pred_predictors
-}
-
 fastml_prepare_xgb_matrix <- function(predictors, feature_names) {
   if (is.null(predictors)) {
     predictors <- data.frame()


### PR DESCRIPTION
## Summary
- move `fastml_prepare_native_survival_predictors()` into a shared utility file so it can be used by all native survival models
- rely on the shared helper from the xgboost survival utilities instead of a file-local definition

## Testing
- not run (Rscript not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db9968c2b8832ab68b8d2173a8a4fb