### PR TITLE
Fix NA survival predictions for flexsurv parametric models

### DIFF
--- a/R/flexsurv_utils.R
+++ b/R/flexsurv_utils.R
@@ -361,6 +361,18 @@ fastml_flexsurv_survival_matrix <- function(fit, newdata, times) {
     }
   }
 
+  if (length(times) > 0 && is.matrix(res) &&
+      nrow(res) == n_obs && ncol(res) == length(times)) {
+    na_rows <- which(rowSums(is.finite(res)) == 0)
+    if (length(na_rows) > 0) {
+      fallback <- compute_rowwise(newdata, times)
+      if (is.matrix(fallback) && nrow(fallback) == n_obs &&
+          ncol(fallback) == length(times)) {
+        res[na_rows, ] <- fallback[na_rows, , drop = FALSE]
+      }
+    }
+  }
+
   expected_dim <- c(n_obs, length(times))
   if (!is.matrix(res)) {
     res <- matrix(as.numeric(res), nrow = expected_dim[1], ncol = expected_dim[2])


### PR DESCRIPTION
## Summary
- add a rowwise flexsurv summary fallback when bulk prediction helpers return missing survival curves
- keep survival probabilities available so downstream risk and metric calculations no longer receive all-NA inputs

## Testing
- not run (R runtime unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68db9b4be68c832a852f591b07bdfc0f