### PR TITLE
Fix flexsurv summary lookup for survival predictions

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -682,8 +682,20 @@ process_model <- function(model_obj,
       n_obs <- nrow(new_data)
       res <- matrix(NA_real_, nrow = n_obs, ncol = length(eval_times))
 
+      summary_fun <- tryCatch(
+        getFromNamespace("summary.flexsurvreg", "flexsurv"),
+        error = function(e) NULL
+      )
+
+      if (!is.function(summary_fun)) {
+        warning(
+          "Unable to access flexsurv summary method; skipping flexsurv predictions."
+        )
+        return(NULL)
+      }
+
       s_list <- tryCatch(
-        flexsurv::summary(
+        summary_fun(
           fit_obj,
           newdata = new_data,
           type = "survival",
@@ -691,7 +703,7 @@ process_model <- function(model_obj,
           ci = FALSE
         ),
         error = function(e) {
-          warning("flexsurv::summary failed: ", e$message)
+          warning("flexsurv summary failed: ", e$message)
           return(NULL)
         }
       )


### PR DESCRIPTION
## Summary
- resolve failures when computing flexsurv-based survival matrices by locating the non-exported summary method via the namespace
- add explicit handling when the flexsurv summary method is unavailable and update warning messages accordingly

## Testing
- `Rscript -e 'testthat::test_dir("tests/testthat")'` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68ee4e0eef68832ab99d72ef19e0ce96