### PR TITLE
Fix flexsurvreg quantile computation in process_model

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -1484,9 +1484,8 @@ process_model <- function(model_obj,
           quantiles_list <- tryCatch({
             quantile(
               final_model$fit,
-              p = 0.5,
-              newdata = flexsurv_newdata,
-              type = "quantile"
+              probs = 0.5,
+              newdata = flexsurv_newdata
             )
           }, error = function(e) {
             warning("Failed to compute quantiles for flexsurvreg: ", e$message)


### PR DESCRIPTION
## Summary
- ensure flexsurvreg quantile computation uses the correct argument name and avoids passing an invalid type string that triggered runtime errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee5b982adc832aacb693b3b9b12201