### PR TITLE
Handle flexsurv quantile calls for parametric survival

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -1481,8 +1481,19 @@ process_model <- function(model_obj,
               nrow(flexsurv_newdata) != nrow(test_data)) {
             flexsurv_newdata <- test_data
           }
+          if (!is.null(flexsurv_newdata) &&
+              !is.data.frame(flexsurv_newdata)) {
+            flexsurv_newdata <- as.data.frame(flexsurv_newdata)
+          }
+          quantile_fun <- getS3method("quantile", "flexsurvreg", optional = TRUE)
+          if (is.null(quantile_fun) && requireNamespace("flexsurv", quietly = TRUE)) {
+            quantile_fun <- getS3method("quantile", "flexsurvreg", optional = TRUE)
+          }
           quantiles_list <- tryCatch({
-            quantile(
+            if (is.null(quantile_fun)) {
+              stop("flexsurv quantile method not available")
+            }
+            quantile_fun(
               final_model$fit,
               probs = 0.5,
               newdata = flexsurv_newdata


### PR DESCRIPTION
## Summary
- ensure flexsurv prediction data is coerced to a data frame before computing quantiles
- look up the flexsurvreg-specific quantile method explicitly so parametric survival models can derive median survival times without errors

## Testing
- Not run (R is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ef4b9a3e50832a90fce2235fe74000