### PR TITLE
Stabilize piecewise exponential survival fitting

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -1466,99 +1466,25 @@ process_model <- function(model_obj,
       brier_time_map <- numeric(0)
     }
 
-    compute_surv_median <- function(prob_mat, eval_times, n_rows) {
-      if (is.null(prob_mat) ||
-          nrow(prob_mat) != n_rows ||
-          ncol(prob_mat) == 0 ||
-          length(eval_times) == 0) {
-        rep(NA_real_, n_rows)
-      } else {
-        median_indices <- apply(prob_mat, 1, function(surv_row) {
-          idx <- which(surv_row <= 0.5)
-          if (length(idx) > 0) {
-            idx[1]
-          } else {
-            NA_integer_
-          }
-        })
+    surv_time <- rep(NA_real_, n_obs)
+    if (!is.null(surv_prob_mat) &&
+        nrow(surv_prob_mat) == n_obs &&
+        ncol(surv_prob_mat) > 0) {
 
-        result <- rep(NA_real_, n_rows)
-        valid_indices <- !is.na(median_indices)
-        if (any(valid_indices)) {
-          result[valid_indices] <- eval_times[median_indices[valid_indices]]
-        }
-        result
-      }
-    }
-
-    align_surv_time <- function(values, n_rows) {
-      if (length(values) == n_rows) {
-        as.numeric(values)
-      } else if (length(values) == 0) {
-        rep(NA_real_, n_rows)
-      } else {
-        aligned <- rep(NA_real_, n_rows)
-        idx <- seq_len(min(length(values), n_rows))
+      median_indices <- apply(surv_prob_mat, 1, function(surv_row) {
+        idx <- which(surv_row <= 0.5)
         if (length(idx) > 0) {
-          aligned[idx] <- as.numeric(values[idx])
+          min(idx)
+        } else {
+          NA_integer_
         }
-        aligned
+      })
+
+      valid_indices <- !is.na(median_indices)
+      if (any(valid_indices)) {
+        surv_time[valid_indices] <- eval_times[median_indices[valid_indices]]
       }
     }
-
-    surv_time_default <- compute_surv_median(surv_prob_mat, eval_times, n_obs)
-
-    surv_time <- tryCatch({
-      if (inherits(final_model, "fastml_native_survival")) {
-        result <- surv_time_default
-        missing_idx <- which(!is.finite(result))
-        if (length(missing_idx) > 0) {
-          fallback <- NULL
-          if (inherits(final_model$fit, "flexsurvreg")) {
-            quantiles_list <- quantile(
-              final_model$fit,
-              p = 0.5,
-              newdata = test_data
-            )
-            fallback_vals <- vapply(quantiles_list, function(x) {
-              if (is.data.frame(x) && "est" %in% names(x)) {
-                as.numeric(x$est[1])
-              } else {
-                NA_real_
-              }
-            }, numeric(1))
-            fallback <- align_surv_time(fallback_vals, n_obs)
-          } else if (requireNamespace("censored", quietly = TRUE)) {
-            if (inherits(final_model$fit, "coxph")) {
-              fallback <- align_surv_time(
-                censored::survival_time_coxph(final_model$fit, pred_predictors),
-                n_obs
-              )
-            } else if (inherits(final_model$fit, "survbagg")) {
-              fallback <- align_surv_time(
-                censored::survival_time_survbagg(final_model$fit, pred_predictors),
-                n_obs
-              )
-            } else if (inherits(final_model$fit, "mboost")) {
-              fallback <- align_surv_time(
-                censored::survival_time_mboost(final_model$fit, pred_predictors),
-                n_obs
-              )
-            }
-          }
-          if (!is.null(fallback)) {
-            result[missing_idx] <- fallback[missing_idx]
-          }
-        }
-        result
-
-      } else {
-        surv_time_default
-      }
-    }, error = function(e) {
-      warning("Computation of survival time failed: ", e$message)
-      rep(NA_real_, n_obs)
-    })
 
     if (identical(survival_model_type, "xgboost_aft")) {
       if (!is.null(aft_quantile_mat) &&


### PR DESCRIPTION
## Summary
- add knot handling to the piecewise exponential trainer, including automatic quantile-based defaults when no cut points are supplied
- compute median survival times directly from predicted survival curves to avoid fragile post-processing
- extend survival tests to cover user-supplied knots and the new default knot heuristic

## Testing
- ⚠️ `R -q -e 'testthat::test_file("tests/testthat/test-survival.R")'` *(fails: R executable is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef5daf6700832a9c2be458c6efdf44