### PR TITLE
Fix piecewise exponential rate extraction for flexsurv integration

### DIFF
--- a/R/piecewise_exp_utils.R
+++ b/R/piecewise_exp_utils.R
@@ -76,10 +76,19 @@ fastml_piecewise_extract_deltas <- function(extra, delta_names) {
 }
 
 fastml_piecewise_rates <- function(log_rate, log_ratios) {
+  log_rate <- as.numeric(log_rate)
+  log_ratios <- as.numeric(log_ratios)
+
+  if (length(log_rate) > 1L) {
+    log_ratios <- c(log_rate[-1L], log_ratios)
+    log_rate <- log_rate[1L]
+  }
+
   pars <- c(log_rate, log_ratios)
   if (any(!is.finite(pars))) {
     return(rep(NA_real_, length(log_ratios) + 1L))
   }
+
   base_rate <- exp(log_rate)
   c(base_rate, base_rate * exp(log_ratios))
 }

--- a/tests/testthat/test-piecewise-exp-utils.R
+++ b/tests/testthat/test-piecewise-exp-utils.R
@@ -1,0 +1,18 @@
+test_that("fastml_piecewise_rates handles scalar inputs", {
+  skip_if_not_installed("flexsurv")
+  base_log_rate <- log(0.1)
+  log_ratios <- log(c(2, 3))
+  res <- fastml:::fastml_piecewise_rates(base_log_rate, log_ratios)
+  expect_length(res, length(log_ratios) + 1L)
+  expect_equal(res, exp(base_log_rate) * c(1, exp(log_ratios)))
+})
+
+test_that("fastml_piecewise_rates accepts vectorised log_rate from flexsurv", {
+  skip_if_not_installed("flexsurv")
+  base_log_rate <- log(0.2)
+  extra_params <- log(c(0.3, 0.4))
+  res <- fastml:::fastml_piecewise_rates(c(base_log_rate, extra_params), numeric(0))
+  expect_length(res, length(extra_params) + 1L)
+  expect_equal(res[1], exp(base_log_rate))
+  expect_equal(res[-1], exp(base_log_rate) * exp(extra_params))
+})


### PR DESCRIPTION
## Summary
- normalize the piecewise exponential rate helper so flexsurv vector inputs are unpacked correctly
- add regression tests covering scalar and vectorized parameter handling for the helper

## Testing
- Not run (R is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ef6935d624832a90e9b4abb92665a3