### PR TITLE
Handle singular Hessian when fitting flexsurv models

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -404,11 +404,7 @@ train_models <- function(train_data,
           data = baked_train,
           dist = dist_flex
         )
-        fit <- call_with_engine_params(
-          flexsurv::flexsurvreg,
-          base_args,
-          engine_args
-        )
+        fit <- fastml_fit_flexsurvreg(base_args, engine_args)
         extras <- list(
           distribution = dist_flex,
           distribution_label = dist_label
@@ -489,11 +485,7 @@ train_models <- function(train_data,
         if (length(pw_spec$aux) > 0) {
           base_args$aux <- pw_spec$aux
         }
-        fit <- call_with_engine_params(
-          flexsurv::flexsurvreg,
-          base_args,
-          engine_args
-        )
+        fit <- fastml_fit_flexsurvreg(base_args, engine_args)
         extras <- list(
           distribution = "fastml_piecewise_exponential",
           distribution_label = "piecewise exponential",


### PR DESCRIPTION
## Summary
- add a flexsurv helper that retries fits without computing the Hessian when the matrix inversion fails
- use the helper for parametric and piecewise exponential survival training paths to avoid singular system errors

## Testing
- Rscript -e "testthat::test_dir('tests/testthat')" *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68efa1ae0118832a88c011c90c135fe9