### PR TITLE
Ensure XGBoost survival risk scores fall back to AFT mean

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -1439,6 +1439,16 @@ process_model <- function(model_obj,
                length(surv_prob) == n_obs && any(is.finite(surv_prob))) {
       risk <- -log(pmax(surv_prob, .Machine$double.eps))
     }
+
+    if (identical(survival_model_type, "xgboost_aft") &&
+        (!any(is.finite(risk)) || all(is.na(risk)))) {
+      if (!is.null(aft_mu) && length(aft_mu) == n_obs) {
+        aft_mu_vec <- as.numeric(aft_mu)
+        if (any(is.finite(aft_mu_vec))) {
+          risk <- -aft_mu_vec
+        }
+      }
+    }
     if (length(risk) != n_obs) {
       risk <- rep(risk, length.out = n_obs)
     }


### PR DESCRIPTION
## Summary
- add a fallback for survival risk scoring so AFT-based XGBoost models reuse the predicted log-time mean when survival curves are unavailable

## Testing
- not run (R is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f1f652c788832a8fbd23a8a8d228a3