### PR TITLE
Fix xgboost AFT manual block to use margin predictions

### DIFF
--- a/R/process_model.R
+++ b/R/process_model.R
@@ -870,18 +870,16 @@ process_model <- function(model_obj,
           } else if (identical(final_model$fit$objective, "survival:aft")) {
             # Manual implementation to replace the failing fastml_xgb_aft_predict() helper.
 
-            # 1. XGBoost predict() requires a numeric matrix as input.
-            # This converts the preprocessed predictors to the correct format.
-            predictor_matrix <- as.matrix(pred_predictors)
+            # 1. Obtain the linear predictor (log-time) using the helper that
+            # ensures margin predictions are requested with the appropriate
+            # fallbacks for different xgboost versions.
+            lp <- fastml_xgb_predict_lp(final_model$fit, pred_predictors)
 
-            # 2. Get the linear predictor (which represents log-time in an AFT model).
-            lp <- predict(final_model$fit$booster, predictor_matrix)
-
-            # 3. Get model parameters stored by fastml.
+            # 2. Get model parameters stored by fastml.
             dist <- final_model$fit$aft_distribution
             scale <- final_model$fit$aft_scale
 
-            # 4. Calculate the survival probability matrix: S(t|lp) = S_0((log(t) - lp) / scale)
+            # 3. Calculate the survival probability matrix: S(t|lp) = S_0((log(t) - lp) / scale)
             if (dist == "logistic") {
               surv_prob_mat <- matrix(NA_real_, nrow = n_obs, ncol = length(eval_times))
               for (i in seq_along(eval_times)) {


### PR DESCRIPTION
## Summary
- ensure the manual xgboost AFT prediction block obtains the linear predictor via the helper that requests margin outputs so survival metrics use the correct scale

## Testing
- Rscript -e "testthat::test_dir('tests/testthat')" *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68f245162cbc832a8fa223f2d3abc5da