### PR TITLE
Fix native survival risk predictions to use preprocessed data

### DIFF
--- a/R/predict.fastml.R
+++ b/R/predict.fastml.R
@@ -159,7 +159,7 @@ predict.fastml <- function(object, newdata,
       if (identical(predict_type, "risk")) {
         risk_pred <- tryCatch({
           if (inherits(wf, "fastml_native_survival")) {
-            predict_risk(wf, newdata = newdata, ...)
+            predict_risk(wf, newdata = new_data_for_predict, ...)
           } else {
             pred_obj <- predict(wf, new_data = new_data_for_predict, type = "linear_pred", ...)
             if (is.data.frame(pred_obj) || tibble::is_tibble(pred_obj)) {


### PR DESCRIPTION
## Summary
- ensure native survival risk predictions consume preprocessed data

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f77cd07a20832a82f39050ba8699b4