### PR TITLE
Guard against data leakage during resampling

### DIFF
--- a/R/fastml.R
+++ b/R/fastml.R
@@ -57,6 +57,11 @@ utils::globalVariables(c("Fraction", "Performance"))
 #'     \item{\code{"error"}}{Do not perform imputation; if missing values are detected, stop execution with an error.}
 #'     \item{\code{NULL}}{Equivalent to \code{"error"}. No imputation is performed, and the function will stop if missing values are present.}
 #'   }
+#'   When resampling is requested (e.g., cross-validation or bootstrapping),
+#'   advanced imputation methods \code{"mice"}, \code{"missForest"}, and
+#'   \code{"custom"} must be supplied as part of a recipe so they can be trained
+#'   on each analysis fold. If these methods are requested directly while
+#'   resampling, the function aborts to avoid information leakage.
 #'   Default is \code{"error"}.
 #' @param impute_custom_function A function that takes a data.frame as input and returns an imputed data.frame. Used only if \code{impute_method = "custom"}.
 #' @param encode_categoricals Logical indicating whether to encode categorical variables. Default is \code{TRUE}.
@@ -184,6 +189,12 @@ fastml <- function(data = NULL,
 
   task <- match.arg(task, c("auto", "classification", "regression", "survival"))
   tuning_strategy <- match.arg(tuning_strategy, c("grid", "bayes", "none"))
+  if (is.null(resampling_method)) {
+    resampling_method <- "none"
+  } else {
+    resampling_method <- tolower(resampling_method)
+  }
+  resampling_active <- !is.null(resamples) || resampling_method != "none"
 
   # If explicit train/test provided, ensure both are given
   if (!is.null(train_data) || !is.null(test_data)) {
@@ -498,6 +509,13 @@ fastml <- function(data = NULL,
   if (is.null(recipe)) {
 
     if (!is.null(impute_method) && impute_method %in% c("mice", "missForest", "custom")) {
+
+      if (resampling_active) {
+        stop(
+          "Advanced imputation methods ('mice', 'missForest', 'custom') must be trained within each resample. ",
+          "Provide these steps inside an untrained recipe or disable resampling (resampling_method = 'none')."
+        )
+      }
 
       outcome_cols <- unique(c(label, if (task == "survival") label_surv else character()))
       outcome_cols <- outcome_cols[outcome_cols %in% names(train_data)]

--- a/tests/testthat/test-fastml.R
+++ b/tests/testthat/test-fastml.R
@@ -37,10 +37,24 @@ test_that("survival task works with mice imputation", {
       algorithms = c("rand_forest"),
       task = "survival",
       test_size = 0.3,
-      impute_method = "mice"
+      impute_method = "mice",
+      resampling_method = "none"
     )
   )
   expect_s3_class(res, "fastml")
+})
+
+test_that("advanced imputation is guarded when resampling is active", {
+  expect_error(
+    fastml(
+      data = iris,
+      label = "Species",
+      algorithms = c("rand_forest"),
+      impute_method = "mice",
+      resampling_method = "cv"
+    ),
+    "Advanced imputation methods ('mice', 'missForest', 'custom') must be trained within each resample."
+  )
 })
 
 test_that("'label' is not available in the data", {


### PR DESCRIPTION
## Summary
- document the need to keep advanced imputation inside fold-specific preprocessing
- normalize resampling method handling and guard against using data-leaking imputers when resampling is active
- adjust and extend tests to cover the guarded behavior

## Testing
- Rscript -e "testthat::test_dir('tests/testthat', reporter = 'summary')" *(fails: command not found: Rscript)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69131ff089c8832a88828ae95b1a37b9)