### PR TITLE
Allow survival resampling for parsnip survival engines

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -851,7 +851,7 @@ train_models <- function(train_data,
         fit_engine_args <- engine_args
       }
 
-      if (!is.null(resamples)) {
+      if (!is.null(resamples) && inherits(spec, "fastml_native_survival")) {
         stop(
           paste(
             "Guarded resampling for survival models is not yet implemented for native engines.",


### PR DESCRIPTION
## Summary
- only guard against resampling when using native survival engines so parsnip specs can still resample

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133963cf50832aa96853e067295afa)