### PR TITLE
Enable fold-wise advanced imputation during resampling

### DIFF
--- a/R/imputation_helpers.R
+++ b/R/imputation_helpers.R
@@ -1,0 +1,167 @@
+# Internal helpers for advanced imputation handling
+
+fastml_apply_advanced_imputation <- function(train_data,
+                                             test_data,
+                                             outcome_cols,
+                                             impute_method,
+                                             impute_custom_function,
+                                             warn = TRUE) {
+  advanced_methods <- c("mice", "missForest", "custom")
+  if (is.null(impute_method) || !(impute_method %in% advanced_methods)) {
+    return(list(train_data = train_data, test_data = test_data))
+  }
+
+  if (impute_method == "custom") {
+    if (!is.function(impute_custom_function)) {
+      stop("You selected impute_method='custom' but did not provide a valid `impute_custom_function`.")
+    }
+    train_data <- impute_custom_function(train_data)
+    if (!is.null(test_data) && nrow(test_data) > 0) {
+      test_data <- impute_custom_function(test_data)
+    }
+    if (warn) {
+      warning("Missing values have been imputed using the 'custom' method.")
+    }
+    return(list(train_data = train_data, test_data = test_data))
+  }
+
+  predictor_cols_train <- setdiff(colnames(train_data), outcome_cols)
+
+  if (impute_method == "mice") {
+    if (!requireNamespace("mice", quietly = TRUE)) {
+      stop("impute_method='mice' requires the 'mice' package to be installed.")
+    }
+
+    if (length(predictor_cols_train) > 0 && nrow(train_data) > 0) {
+      train_predictors <- train_data[, predictor_cols_train, drop = FALSE]
+      matrix_cols_train <- vapply(train_predictors, is.matrix, logical(1))
+      if (any(matrix_cols_train)) {
+        train_matrix <- train_predictors[, matrix_cols_train, drop = FALSE]
+        train_non_matrix <- train_predictors[, !matrix_cols_train, drop = FALSE]
+        if (ncol(train_non_matrix) > 0) {
+          train_data_mice <- mice::mice(train_non_matrix)
+          train_non_matrix <- mice::complete(train_data_mice)
+        }
+        train_predictors <- cbind(train_non_matrix, train_matrix)
+        train_predictors <- train_predictors[, predictor_cols_train, drop = FALSE]
+      } else {
+        train_data_mice <- mice::mice(train_predictors)
+        train_predictors <- mice::complete(train_data_mice)
+      }
+      train_data[, predictor_cols_train] <- train_predictors
+    }
+
+    if (!is.null(test_data) && nrow(test_data) > 0) {
+      test_predictor_cols <- setdiff(colnames(test_data), outcome_cols)
+      if (length(test_predictor_cols) > 0) {
+        test_predictors <- test_data[, test_predictor_cols, drop = FALSE]
+        matrix_cols_test <- vapply(test_predictors, is.matrix, logical(1))
+        if (any(matrix_cols_test)) {
+          test_matrix <- test_predictors[, matrix_cols_test, drop = FALSE]
+          test_non_matrix <- test_predictors[, !matrix_cols_test, drop = FALSE]
+          if (ncol(test_non_matrix) > 0) {
+            if (!exists("train_data_mice")) {
+              train_data_mice <- mice::mice(train_data[, predictor_cols_train, drop = FALSE])
+            }
+            test_data_mice <- mice::mice(
+              test_non_matrix,
+              maxit = train_data_mice$iteration,
+              meth = train_data_mice$meth,
+              predictorMatrix = train_data_mice$predictorMatrix
+            )
+            test_non_matrix <- mice::complete(test_data_mice, action = 1)
+          }
+          test_predictors <- cbind(test_non_matrix, test_matrix)
+          test_predictors <- test_predictors[, test_predictor_cols, drop = FALSE]
+        } else {
+          if (!exists("train_data_mice")) {
+            train_data_mice <- mice::mice(train_data[, predictor_cols_train, drop = FALSE])
+          }
+          test_data_mice <- mice::mice(
+            test_predictors,
+            maxit = train_data_mice$iteration,
+            meth = train_data_mice$meth,
+            predictorMatrix = train_data_mice$predictorMatrix
+          )
+          test_predictors <- mice::complete(test_data_mice, action = 1)
+        }
+        test_data[, test_predictor_cols] <- test_predictors
+      }
+    }
+
+    if (warn) {
+      warning("Missing values have been imputed using the 'mice' method.")
+    }
+    return(list(train_data = train_data, test_data = test_data))
+  }
+
+  if (impute_method == "missForest") {
+    if (!requireNamespace("missForest", quietly = TRUE)) {
+      stop("impute_method='missForest' requires the 'missForest' package to be installed.")
+    }
+
+    if (length(predictor_cols_train) > 0 && nrow(train_data) > 0) {
+      train_data_imp <- missForest::missForest(train_data[, predictor_cols_train, drop = FALSE], verbose = FALSE)
+      imputed_train <- train_data_imp$ximp
+      train_data[, predictor_cols_train] <- imputed_train[, predictor_cols_train, drop = FALSE]
+    }
+
+    if (!is.null(test_data) && nrow(test_data) > 0) {
+      test_predictor_cols <- setdiff(colnames(test_data), outcome_cols)
+      if (length(test_predictor_cols) > 0) {
+        test_data_imp <- missForest::missForest(test_data[, test_predictor_cols, drop = FALSE], verbose = FALSE)
+        imputed_test <- test_data_imp$ximp
+        test_data[, test_predictor_cols] <- imputed_test[, test_predictor_cols, drop = FALSE]
+      }
+    }
+
+    if (warn) {
+      warning("Missing values have been imputed using the 'missForest' method.")
+    }
+    return(list(train_data = train_data, test_data = test_data))
+  }
+
+  list(train_data = train_data, test_data = test_data)
+}
+
+fastml_impute_resamples <- function(resamples,
+                                    impute_method,
+                                    impute_custom_function,
+                                    outcome_cols) {
+  if (is.null(resamples) || length(resamples$splits) == 0) {
+    return(resamples)
+  }
+
+  resamples$splits <- lapply(resamples$splits, function(split) {
+    data <- split$data
+    analysis_idx <- split$in_id
+    assessment_idx <-
+      if (!is.null(split$out_id) && !all(is.na(split$out_id))) {
+        split$out_id
+      } else {
+        rsample::complement(split)
+      }
+
+    analysis_data <- data[analysis_idx, , drop = FALSE]
+    assessment_data <- data[assessment_idx, , drop = FALSE]
+
+    imputed <- fastml_apply_advanced_imputation(
+      train_data = analysis_data,
+      test_data = assessment_data,
+      outcome_cols = outcome_cols,
+      impute_method = impute_method,
+      impute_custom_function = impute_custom_function,
+      warn = FALSE
+    )
+
+    data[analysis_idx, ] <- imputed$train_data
+    if (length(assessment_idx) > 0) {
+      data[assessment_idx, ] <- imputed$test_data
+    }
+
+    split$data <- data
+    split
+  })
+
+  resamples
+}

--- a/man/fastml.Rd
+++ b/man/fastml.Rd
@@ -113,6 +113,9 @@ hyperparameters to explore during tuning. Default is an empty list.}
   \item{\code{"error"}}{Do not perform imputation; if missing values are detected, stop execution with an error.}
   \item{\code{NULL}}{Equivalent to \code{"error"}. No imputation is performed, and the function will stop if missing values are present.}
 }
+When resampling is requested (e.g., cross-validation or bootstrapping),
+\code{fastml()} automatically fits the selected advanced imputation method inside
+each resample and applies it to that fold's assessment data before evaluation.
 Default is \code{"error"}.}
 
 \item{impute_custom_function}{A function that takes a data.frame as input and returns an imputed data.frame. Used only if \code{impute_method = "custom"}.}

--- a/man/train_models.Rd
+++ b/man/train_models.Rd
@@ -13,6 +13,10 @@ train_models(
   folds,
   repeats,
   resamples = NULL,
+  resample_base_data = NULL,
+  impute_method = NULL,
+  impute_custom_function = NULL,
+  impute_outcome_cols = NULL,
   tune_params,
   engine_params = list(),
   metric,
@@ -50,6 +54,19 @@ train_models(
 
 \item{resamples}{Optional rsample object. If provided, custom resampling splits
 will be used instead of those created internally.}
+
+\item{resample_base_data}{Optional data frame used to generate resamples when
+different from \code{train_data} (for example, before advanced imputation has
+been applied).}
+
+\item{impute_method}{Advanced imputation method to apply inside each resample.
+Only \code{"mice"}, \code{"missForest"}, or \code{"custom"} are supported.}
+
+\item{impute_custom_function}{Custom function used when
+\code{impute_method = "custom"}.}
+
+\item{impute_outcome_cols}{Character vector of outcome columns that should be
+excluded from imputation.}
 
 \item{tune_params}{A named list of tuning ranges. For each algorithm, supply a
 list of engine-specific parameter values, e.g.


### PR DESCRIPTION
## Summary
- add internal helpers to apply advanced imputers to training/test splits without leaking outcomes
- update fastml() and train_models() to reuse raw data for resamples and automatically impute each assessment fold
- refresh documentation and tests to reflect the new resampling support for advanced imputation methods

## Testing
- not run (R CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69133aaedda0832a81f486b9a1c16499)