### PR TITLE
Ensure sandbox fetch retrieves exported functions

### DIFF
--- a/R/security_guards.R
+++ b/R/security_guards.R
@@ -235,8 +235,7 @@ fastml_fetch_sandbox_function <- function(name) {
     if (!base::requireNamespace(pkg, quietly = TRUE)) {
       next
     }
-    ns <- base::asNamespace(pkg)
-    if (exists(name, envir = ns, inherits = FALSE)) {
+    if (name %in% base::getNamespaceExports(pkg)) {
       return(base::getExportedValue(pkg, name))
     }
   }


### PR DESCRIPTION
## Summary
- ensure sandbox function lookup only returns exported objects

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b910fd28832a871deeabf52709f4)