### PR TITLE
Fix block count calculation in blocked CV

### DIFF
--- a/R/train_models.R
+++ b/R/train_models.R
@@ -1092,7 +1092,7 @@ train_models <- function(train_data,
         dplyr::mutate(
           .fastml_block = ceiling(dplyr::row_number() / block_size)
         )
-      n_blocks <- dplyr::n_distinct(.fastml_block)
+      n_blocks <- dplyr::n_distinct(resample_data$.fastml_block)
       if (folds > n_blocks) {
         stop("'folds' cannot exceed the number of derived blocks.")
       }


### PR DESCRIPTION
## Summary
- update the blocked cross-validation workflow to count block identifiers from the resample data frame
- prevent failures when computing the number of derived blocks during blocked CV setup

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c1946f9c832a84d69f22a60b1a1d)