### PR TITLE
Implement unbiased nested cross-validation

### DIFF
--- a/R/imputation_helpers.R
+++ b/R/imputation_helpers.R
@@ -200,5 +200,21 @@ fastml_impute_resamples <- function(resamples,
     split
   })
 
+  if (!is.null(resamples$inner_resamples)) {
+    resamples$inner_resamples <- lapply(resamples$inner_resamples, function(inner) {
+      if (inherits(inner, "rset")) {
+        fastml_impute_resamples(
+          resamples = inner,
+          impute_method = impute_method,
+          impute_custom_function = impute_custom_function,
+          outcome_cols = outcome_cols,
+          audit_env = audit_env
+        )
+      } else {
+        inner
+      }
+    })
+  }
+
   resamples
 }


### PR DESCRIPTION
## Summary
- add a dedicated nested resampling constructor and helper to tune models within inner folds and score outer assessments without leakage
- update the nested cross-validation training path to record inner tuning artifacts, outer metrics, and final hyperparameters while attaching them to the fastml result
- extend resample imputation and result assembly so nested resamples are imputed safely and exposed via the fastml output

## Testing
- Rscript not available in the execution environment

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691731c26354832aa01c8aba794eb928)